### PR TITLE
Update demo/patient-search to 46ec9cd

### DIFF
--- a/charts/patient-search/values-demo.yaml
+++ b/charts/patient-search/values-demo.yaml
@@ -5,7 +5,7 @@ env: "demo"
 image:
   repository: ""
   pullPolicy: IfNotPresent
-  tag: "1.0.1-SNAPSHOT.d92dde4"
+  tag: "1.0.1-SNAPSHOT.46ec9cd"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Updates the Patient Search version to [46ec9cd](https://github.com/CDCgov/NEDSS-Modernization/commit/46ec9cdc0860674c8380278f47a5925c8f07d56e) for the Demo environment.