### PR TITLE
[INT1] Updates NiFi version to 1.19.0-SNAPSHOT.43ae4c5

### DIFF
--- a/charts/nifi/values-int1.yaml
+++ b/charts/nifi/values-int1.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: ""
   pullPolicy: IfNotPresent
-  tag: 1.19.0-SNAPSHOT.5e98d03
+  tag: 1.19.0-SNAPSHOT.43ae4c5
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Requesting deployment of the `1.19.0-SNAPSHOT.43ae4c5` NiFi container to INT1.