### PR TITLE
limit resources

### DIFF
--- a/charts/elasticsearch/values-dev.yaml
+++ b/charts/elasticsearch/values-dev.yaml
@@ -33,9 +33,11 @@ ingress:
   annotations: {}
   tls: []
 
-resources: 
+resources:
+  requests:
+    memory: "2Gi"
   limits:
-    memory: "4Gi"
+    memory: "2Gi"
 
 autoscaling:
   enabled: false

--- a/charts/modernization-api/values-dev.yaml
+++ b/charts/modernization-api/values-dev.yaml
@@ -47,7 +47,11 @@ istioGatewayIngress:
   certificateName: ""
   certificateIssuerName: "letsencrypt-production"
 
-resources: {}
+resources:
+  requests:
+    memory: "2Gi"
+  limits:
+    memory: "2Gi"
 
 autoscaling:
   enabled: false

--- a/charts/nifi/values-dev.yaml
+++ b/charts/nifi/values-dev.yaml
@@ -48,13 +48,15 @@ ingress:
             port:
               number: 8443
 
-resources: 
+resources:
+  requests:
+    memory: "2Gi"
   limits:
-    memory: "4Gi"
+    memory: "2Gi"
 
 jvmheap:
-  init: "2g"
-  max: "2g"
+  init: "1g"
+  max: "1g"
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
Limit resources to containers deployed in dev to prevent errors. This can sit in PR until approved by other teams through jira.