### PR TITLE
Allow PageBuilder to handle redirections

### DIFF
--- a/charts/nbs-gateway/templates/deployment.yaml
+++ b/charts/nbs-gateway/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: {{ .Chart.Name }}
-        args: ['--nbs.gateway.classic=https://{{ .Values.nbsExternalName }}','--nbs.gateway.patient.search.service={{ .Values.modernizationApiHost }}','--nbs.gateway.patient.profile.service={{ .Values.modernizationApiHost }}','--nbs.gateway.pagebuilder.service={{ .Values.modernizationApiHost }}', '--nbs.gateway.pagebuilder.enabled={{ .Values.pageBuilder.enabled }}']
+        args: ['--nbs.gateway.classic=https://{{ .Values.nbsExternalName }}','--nbs.gateway.patient.search.service={{ .Values.modernizationApiHost }}','--nbs.gateway.patient.profile.service={{ .Values.modernizationApiHost }}','--nbs.gateway.pagebuilder.service={{ .Values.pagebuilderApiHost }}', '--nbs.gateway.pagebuilder.enabled={{ .Values.pageBuilder.enabled }}']
         command: ['java', '-jar', 'api.jar']
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         ports:

--- a/charts/nbs-gateway/values-auto.yaml
+++ b/charts/nbs-gateway/values-auto.yaml
@@ -29,3 +29,5 @@ nbsExternalName: app-classic.ai-cdc-nbs.eqsandbox.com
 ingressHost: "app.ai-cdc-nbs.eqsandbox.com"
 
 modernizationApiHost: "modernization-api.default.svc.cluster.local:8080"
+
+pagebuilderApiHost: "page-builder-api.default.svc.cluster.local:8095"

--- a/charts/nbs-gateway/values-int1.yaml
+++ b/charts/nbs-gateway/values-int1.yaml
@@ -29,3 +29,5 @@ nbsExternalName: app-classic.int1.nbspreview.com
 ingressHost: "app.int1.nbspreview.com"
 
 modernizationApiHost: "modernization-api.default.svc.cluster.local:8080"
+
+pagebuilderApiHost: "page-builder-api.default.svc.cluster.local:8095"

--- a/charts/nbs-gateway/values.yaml
+++ b/charts/nbs-gateway/values.yaml
@@ -29,3 +29,5 @@ nbsExternalName: app-classic.example.com
 ingressHost:  
 
 modernizationApiHost: "modernization-api.default.svc.cluster.local:8080"
+
+pagebuilderApiHost: "page-builder-api.default.svc.cluster.local:8095"


### PR DESCRIPTION
Updates the Page Builder service to point to the Page Builder API container. 

* Dependent on classic redirect library being added to Page builder in upcoming PR.
