### PR TITLE
Add page library, management feature flags for page builder

### DIFF
--- a/charts/modernization-api/templates/deployment.yaml
+++ b/charts/modernization-api/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
               containerPort: 8080
               protocol: TCP
           command: ['java', '-jar', 'api.jar']
-          args: ['--nbs.elasticsearch.url={{ .Values.elasticSearchHost }}', '--spring.datasource.url={{ .Values.jdbc.connectionString }}', '--spring.datasource.username={{ .Values.jdbc.user }}', '--spring.datasource.password={{ .Values.jdbc.password }}', '--nbs.wildfly.url=https://{{ .Values.nbsExternalName }}', '--nbs.ui.features.pageBuilder.enabled={{ .Values.pageBuilder.enabled }}']
+          args: ['--nbs.elasticsearch.url={{ .Values.elasticSearchHost }}', '--spring.datasource.url={{ .Values.jdbc.connectionString }}', '--spring.datasource.username={{ .Values.jdbc.user }}', '--spring.datasource.password={{ .Values.jdbc.password }}', '--nbs.wildfly.url=https://{{ .Values.nbsExternalName }}', '--nbs.ui.features.pageBuilder.enabled={{ .Values.pageBuilder.enabled }}', '--nbs.ui.features.pageBuilder.page.library.enabled={{ .Values.pageBuilder.page.library.enabled }}','--nbs.ui.features.pageBuilder.page.management.enabled={{ .Values.pageBuilder.page.management.enabled }}']
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/modernization-api/values-int1.yaml
+++ b/charts/modernization-api/values-int1.yaml
@@ -31,6 +31,11 @@ service:
 
 pageBuilder:
   enabled: "true"
+  page:
+    library:
+      enabled: "true"
+    management:
+      enabled: "true"
 
 ingress:
   enabled: true

--- a/charts/modernization-api/values-test2.yaml
+++ b/charts/modernization-api/values-test2.yaml
@@ -31,6 +31,11 @@ service:
 
 pageBuilder:
   enabled: "false"
+  page:
+    library:
+      enabled: "false"
+    management:
+      enabled: "false"
 
 # nginx-ingress
 ingress:

--- a/charts/modernization-api/values.yaml
+++ b/charts/modernization-api/values.yaml
@@ -31,6 +31,11 @@ service:
 
 pageBuilder:
   enabled: "false"
+  page:
+    library:
+      enabled: "false"
+    management:
+      enabled: "false"
 
 ingress:
   enabled: true

--- a/charts/nbs-gateway/templates/deployment.yaml
+++ b/charts/nbs-gateway/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: {{ .Chart.Name }}
-        args: ['--nbs.gateway.classic=https://{{ .Values.nbsExternalName }}','--nbs.gateway.patient.search.service={{ .Values.modernizationApiHost }}','--nbs.gateway.patient.profile.service={{ .Values.modernizationApiHost }}','--nbs.gateway.pagebuilder.service={{ .Values.pagebuilderApiHost }}', '--nbs.gateway.pagebuilder.enabled={{ .Values.pageBuilder.enabled }}']
+        args: ['--nbs.gateway.classic=https://{{ .Values.nbsExternalName }}','--nbs.gateway.patient.search.service={{ .Values.modernizationApiHost }}','--nbs.gateway.patient.profile.service={{ .Values.modernizationApiHost }}','--nbs.gateway.pagebuilder.service={{ .Values.pagebuilderApiHost }}', '--nbs.gateway.pagebuilder.enabled={{ .Values.pageBuilder.enabled }}', '--nbs.gateway.pagebuilder.page.library.enabled={{ .Values.pageBuilder.page.library.enabled }}','--nbs.gateway.pagebuilder.page.management.enabled={{ .Values.pageBuilder.page.management.enabled }}']
         command: ['java', '-jar', 'api.jar']
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         ports:

--- a/charts/nbs-gateway/values-int1.yaml
+++ b/charts/nbs-gateway/values-int1.yaml
@@ -21,6 +21,11 @@ kubernetesClusterDomain: cluster.local
 
 pageBuilder:
   enabled: "true"
+  page:
+    library:
+      enabled: "true"
+    management:
+      enabled: "true"
 
 resources: {}
 

--- a/charts/nbs-gateway/values-test2.yaml
+++ b/charts/nbs-gateway/values-test2.yaml
@@ -19,6 +19,14 @@ gatewayService:
   type: ClusterIP
 kubernetesClusterDomain: cluster.local
 
+pageBuilder:
+  enabled: "false"
+  page:
+    library:
+      enabled: "false"
+    management:
+      enabled: "false"
+
 resources: {}
 
 nbsExternalName: app-classic.test.nbspreview.com

--- a/charts/nbs-gateway/values.yaml
+++ b/charts/nbs-gateway/values.yaml
@@ -21,6 +21,11 @@ kubernetesClusterDomain: cluster.local
 
 pageBuilder:
   enabled: "false"
+  page:
+    library:
+      enabled: "false"
+    management:
+      enabled: "false"
 
 resources: {}
 


### PR DESCRIPTION
Adds the following feature flags to the configuration passed to the nbs-gateway and modernization-api at startup.

The intent is to allow the feature flagging of the `Page Library` and `Page Management` screens.

```
pageBuilder:
  page:
    library:
      enabled: "true"
    management:
      enabled: "true"
```