### PR TITLE
Update test2 to enable page builder library

### DIFF
--- a/charts/modernization-api/values-test2.yaml
+++ b/charts/modernization-api/values-test2.yaml
@@ -30,10 +30,10 @@ service:
   pageBuilderPort: 8095
 
 pageBuilder:
-  enabled: "false"
+  enabled: "true"
   page:
     library:
-      enabled: "false"
+      enabled: "true"
     management:
       enabled: "false"
 

--- a/charts/nbs-gateway/values-test2.yaml
+++ b/charts/nbs-gateway/values-test2.yaml
@@ -20,10 +20,10 @@ gatewayService:
 kubernetesClusterDomain: cluster.local
 
 pageBuilder:
-  enabled: "false"
+  enabled: "true"
   page:
     library:
-      enabled: "false"
+      enabled: "true"
     management:
       enabled: "false"
 


### PR DESCRIPTION
Release 7.2 will include the PageBuilder Page Library. This PR enables the Page Library while keeping the management screens disabled.