### PR TITLE
Disables PageBuilder in test2 env

### DIFF
--- a/charts/modernization-api/values-test2.yaml
+++ b/charts/modernization-api/values-test2.yaml
@@ -30,10 +30,10 @@ service:
   pageBuilderPort: 8095
 
 pageBuilder:
-  enabled: "true"
+  enabled: "false"
   page:
     library:
-      enabled: "true"
+      enabled: "false"
     management:
       enabled: "false"
 

--- a/charts/nbs-gateway/values-test2.yaml
+++ b/charts/nbs-gateway/values-test2.yaml
@@ -20,10 +20,10 @@ gatewayService:
 kubernetesClusterDomain: cluster.local
 
 pageBuilder:
-  enabled: "true"
+  enabled: "false"
   page:
     library:
-      enabled: "true"
+      enabled: "false"
     management:
       enabled: "false"
 


### PR DESCRIPTION
The PageBuilder Page Library will no longer be included in the 7.2 release. This PR updates the flags to disable this feature in the test environment.