### PR TITLE
INT1 - Disable edit flag

### DIFF
--- a/charts/modernization-api/values-int1.yaml
+++ b/charts/modernization-api/values-int1.yaml
@@ -38,7 +38,7 @@ pageBuilder:
       create:
         enabled: "true"
       edit:
-        enabled: "true"
+        enabled: "false"
 
 ingress:
   enabled: true

--- a/charts/nbs-gateway/values-int1.yaml
+++ b/charts/nbs-gateway/values-int1.yaml
@@ -28,7 +28,7 @@ pageBuilder:
       create:
         enabled: "true"
       edit:
-        enabled: "true"
+        enabled: "false"
 
 resources: {}
 


### PR DESCRIPTION
In order to thoroughly test the feature flags we need to temporarily disable the `edit` flag for the `int1` environment. 

Once this has been done and the feature flag tested, a follow up PR will be created to revert the change.