### PR TITLE
Enable PageBuilder Library and Page Create in test environment

### DIFF
--- a/charts/modernization-api/values-test2.yaml
+++ b/charts/modernization-api/values-test2.yaml
@@ -30,13 +30,13 @@ service:
   pageBuilderPort: 8095
 
 pageBuilder:
-  enabled: "false"
+  enabled: "true"
   page:
     library:
-      enabled: "false"
+      enabled: "true"
     management:
       create:
-        enabled: "false"
+        enabled: "true"
       edit:
         enabled: "false"
 

--- a/charts/nbs-gateway/values-test2.yaml
+++ b/charts/nbs-gateway/values-test2.yaml
@@ -20,13 +20,13 @@ gatewayService:
 kubernetesClusterDomain: cluster.local
 
 pageBuilder:
-  enabled: "false"
+  enabled: "true"
   page:
     library:
-      enabled: "false"
+      enabled: "true"
     management:
       create:
-        enabled: "false"
+        enabled: "true"
       edit:
         enabled: "false"
 


### PR DESCRIPTION
The Page Builder `Page Library` and `Page Create` pages will be enabled for release 7.2.2. 

An upcoming PR will deploy the 7.2.2 release candidate to the test environment.