### PR TITLE
Disable PB in test 

### DIFF
--- a/charts/modernization-api/values-test2.yaml
+++ b/charts/modernization-api/values-test2.yaml
@@ -30,13 +30,13 @@ service:
   pageBuilderPort: 8095
 
 pageBuilder:
-  enabled: "true"
+  enabled: "false"
   page:
     library:
-      enabled: "true"
+      enabled: "false"
     management:
       create:
-        enabled: "true"
+        enabled: "false"
       edit:
         enabled: "false"
 

--- a/charts/nbs-gateway/values-test2.yaml
+++ b/charts/nbs-gateway/values-test2.yaml
@@ -20,13 +20,13 @@ gatewayService:
 kubernetesClusterDomain: cluster.local
 
 pageBuilder:
-  enabled: "true"
+  enabled: "false"
   page:
     library:
-      enabled: "true"
+      enabled: "false"
     management:
       create:
-        enabled: "true"
+        enabled: "false"
       edit:
         enabled: "false"
 


### PR DESCRIPTION
We are yet again delaying the release of page builder and excluding it from release 7.2.2. 

This PR disables the page builder features in the test environment by reverting the commit that enabled them.

This reverts commit 420995716be0de69dd084ba58ea089e4895b80ee.