### PR TITLE
Update feature to current int1 containers. Enable edit in page builder

### DIFF
--- a/charts/modernization-api/values-feature.yaml
+++ b/charts/modernization-api/values-feature.yaml
@@ -5,7 +5,7 @@ env: "feature"
 image:
   repository: ""
   pullPolicy: IfNotPresent
-  tag: 1.0.1-SNAPSHOT.4916441
+  tag: 1.0.1-SNAPSHOT.b8bde58
 
 imagePullSecrets: []
 nameOverride: ""
@@ -38,7 +38,7 @@ pageBuilder:
       create:
         enabled: "true"
       edit:
-        enabled: "false"
+        enabled: "true"
 
 ingress:
   enabled: true

--- a/charts/nbs-gateway/values-feature.yaml
+++ b/charts/nbs-gateway/values-feature.yaml
@@ -28,7 +28,7 @@ pageBuilder:
       create:
         enabled: "true"
       edit:
-        enabled: "false"
+        enabled: "true"
 
 resources: {}
 

--- a/charts/page-builder-api/values-feature.yaml
+++ b/charts/page-builder-api/values-feature.yaml
@@ -5,7 +5,7 @@ env: "feature"
 image:
   repository: ""
   pullPolicy: IfNotPresent
-  tag: 1.0.1-SNAPSHOT.4d0fdf2
+  tag: 1.0.1-SNAPSHOT.b8bde58
 
 # Host URL for application
 ingressHost: app.feature.nbspreview.com


### PR DESCRIPTION
Updates the feature environment with the current `int1` containers for 
* modernization-api
* nbs-gateway
* page-builder-api

Enables Page Management `Edit` feature flag.