### PR TITLE
fix selector labels

### DIFF
--- a/charts/modernization-api/templates/ingress.yaml
+++ b/charts/modernization-api/templates/ingress.yaml
@@ -7,9 +7,12 @@ metadata:
   name: main-ingress-resource
   annotations:
     cert-manager.io/cluster-issuer: "letsencrypt-production"
-    {{- if .Values.mTLS.enabled }}
-    nginx.ingress.kubernetes.io/service-upstream: "true"    
-    {{- end }}
+    nginx.ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600"
+    # nginx.ingress.kubernetes.io/use-regex: "true"
+    #nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 spec:
   ingressClassName: {{ .Values.ingress.className }}
   tls:
@@ -19,14 +22,7 @@ spec:
   rules:
     - host: {{ .Values.ingressHost }}
       http:
-        paths:
-          - path: "/"
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
+        paths:          
           - path: "/nbs/redirect/"
             pathType: Prefix
             backend:
@@ -40,21 +36,7 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  number: {{ $svcPort }}
-          - path: /images/nedssLogo.jpg
-            pathType: Exact
-            backend:
-              service:
-                name: nbs-gateway-svc
-                port:
-                  number: {{ .Values.service.gatewayPort }}
-          - path: "/nbs/"
-            pathType: Prefix
-            backend:
-              service:
-                name: nbs-gateway-svc
-                port:
-                  number: {{ .Values.service.gatewayPort }}
+                  number: {{ $svcPort }}                  
           {{- if eq .Values.pageBuilder.enabled "true" }}
           - path: "/nbs/page-builder/"
             pathType: Prefix
@@ -64,4 +46,32 @@ spec:
                 port:
                   number: {{ .Values.service.pageBuilderPort }}
           {{- end }}
+          - path: "/nbs/"
+            pathType: Prefix
+            backend:
+              service:
+                name: nbs-gateway-svc  #nbs-gateway-ext
+                port:
+                  number: {{ .Values.service.gatewayPort }} #443
+          - path: /images/nedssLogo.jpg
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: nbs-gateway-svc #nbs-gateway-ext
+                port:
+                  number: {{ .Values.service.gatewayPort }} #443  
+          - path: /favicon.ico
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: nbs-gateway-svc  #nbs-gateway-ext
+                port:
+                  number: {{ .Values.service.gatewayPort }} #443
+          - path: "/"
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
 {{- end }}

--- a/charts/modernization-api/templates/ingress.yaml
+++ b/charts/modernization-api/templates/ingress.yaml
@@ -8,9 +8,9 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: "letsencrypt-production"
     nginx.ingress.kubernetes.io/service-upstream: "true"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
-    nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600"
+    # nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    # nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    # nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600"
     # nginx.ingress.kubernetes.io/use-regex: "true"
     #nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 spec:

--- a/charts/modernization-api/values-fts1.yaml
+++ b/charts/modernization-api/values-fts1.yaml
@@ -3,9 +3,9 @@ replicaCount: 1
 env: "fts1"
 
 image:
-  repository: ""
+  repository: "public.ecr.aws/o1z7u2g7/cdc-nbs-modernization/modernization-api"
   pullPolicy: IfNotPresent
-  tag: 1.0.1-SNAPSHOT.bc0286c
+  tag: v1.0.9
 
 imagePullSecrets: []
 nameOverride: ""
@@ -30,7 +30,7 @@ service:
   pageBuilderPort: 8095
 
 pageBuilder:
-  enabled: "true"
+  enabled: "false"
 
 ingress:
   enabled: true
@@ -74,9 +74,9 @@ ingressHost: "app.fts1.nbspreview.com"
 elasticSearchHost: "http://elasticsearch.default.svc.cluster.local:9200"
 
 jdbc:
-  connectionString: ""
-  user: ""
-  password: ""
+  connectionString: "jdbc:sqlserver://nbs-db.private-fts1.nbspreview.com:1433;databaseName=NBS_ODSE;user=nbs_ods;password=ods;encrypt=true;trustServerCertificate=true;"
+  user: "nbs_ods"
+  password: "ods"
 
 ui:
   smarty:

--- a/charts/modernization-api/values-fts1.yaml
+++ b/charts/modernization-api/values-fts1.yaml
@@ -74,9 +74,9 @@ ingressHost: "app.fts1.nbspreview.com"
 elasticSearchHost: "http://elasticsearch.default.svc.cluster.local:9200"
 
 jdbc:
-  connectionString: "jdbc:sqlserver://nbs-db.private-fts1.nbspreview.com:1433;databaseName=NBS_ODSE;user=nbs_ods;password=ods;encrypt=true;trustServerCertificate=true;"
-  user: "nbs_ods"
-  password: "ods"
+  connectionString: ""
+  user: ""
+  password: ""
 
 ui:
   smarty:

--- a/charts/nbs-gateway/templates/_helpers.tpl
+++ b/charts/nbs-gateway/templates/_helpers.tpl
@@ -34,6 +34,8 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "nbs-gateway.labels" -}}
+app: NBS
+type: App
 helm.sh/chart: {{ include "nbs-gateway.chart" . }}
 {{ include "nbs-gateway.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
@@ -46,6 +48,10 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "nbs-gateway.selectorLabels" -}}
+app: NBS
+type: App
+app.kubernetes.io/name: {{ include "nbs-gateway.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*

--- a/charts/nbs-gateway/templates/deployment.yaml
+++ b/charts/nbs-gateway/templates/deployment.yaml
@@ -3,19 +3,20 @@ kind: Deployment
 metadata:
   name: {{ include "nbs-gateway.fullname" . }}-deployment
   labels:
-    app: NBS
-    type: App
+    {{- include "nbs-gateway.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.deployment.replicas }}
   selector:
     matchLabels:
-      app: NBS
-      type: App
+      {{- include "nbs-gateway.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
-        app: NBS
-        type: App
+        {{- include "nbs-gateway.selectorLabels" . | nindent 8 }}
     spec:
       containers:
       - name: {{ .Chart.Name }}
@@ -26,4 +27,17 @@ spec:
         - containerPort: 8000
         resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
      

--- a/charts/nbs-gateway/templates/gateway-service.yaml
+++ b/charts/nbs-gateway/templates/gateway-service.yaml
@@ -7,8 +7,6 @@ metadata:
 spec:
   type: {{ .Values.gatewayService.type }}
   selector:
-    app: NBS
-    type: App
-  {{- include "nbs-gateway.selectorLabels" . | nindent 4 }}
+    {{- include "nbs-gateway.selectorLabels" . | nindent 4 }}
   ports:
 	{{- .Values.gatewayService.ports | toYaml | nindent 2 -}}

--- a/charts/nbs-gateway/values-fts1.yaml
+++ b/charts/nbs-gateway/values-fts1.yaml
@@ -4,9 +4,9 @@ deployment:
 env: "auto"
 
 image:
-  repository: ""
+  repository: "public.ecr.aws/o1z7u2g7/cdc-nbs-modernization/nbs-gateway"
   pullPolicy: IfNotPresent
-  tag: 1.0.1-SNAPSHOT.4683cd1
+  tag: v1.0.9
 
 gatewayService:
   ports:
@@ -19,14 +19,22 @@ gatewayService:
   type: ClusterIP
 kubernetesClusterDomain: cluster.local
 
+podAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
 pageBuilder:
   enabled: "false"
 
 resources: {}
+  # requests:
+  #   cpu: "1"
 
-nbsExternalName: app-classic.ai-cdc-nbs.eqsandbox.com
+nbsExternalName: app-classic.fts1.nbspreview.com
 
-ingressHost: "app.ai-cdc-nbs.eqsandbox.com"
+ingressHost: "app.fts1.nbspreview.com"
 
 modernizationApiHost: "modernization-api.default.svc.cluster.local:8080"
 

--- a/charts/nbs-gateway/values.yaml
+++ b/charts/nbs-gateway/values.yaml
@@ -39,3 +39,16 @@ ingressHost:
 modernizationApiHost: "modernization-api.default.svc.cluster.local:8080"
 
 pagebuilderApiHost: "page-builder-api.default.svc.cluster.local:8095"
+
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/nginx-ingress/values.yaml
+++ b/charts/nginx-ingress/values.yaml
@@ -1,5 +1,7 @@
 # Used with official helm chart
 controller:
+  podAnnotations:
+    linkerd.io/inject: enabled
   config:
     compute-full-forwarded-for: "true"
     use-forwarded-headers: "true"


### PR DESCRIPTION
HOLD merge until we a re ready to update all environments (sandboxs, int1, test)

Fix is to update selector label on nbs-gateway so the ingress controller does not get confused. Updates on values and configuration files so deployments are flexible and match.