### PR TITLE
allow x-frame-options for classic app iframes

### DIFF
--- a/charts/modernization-api/templates/ingress.yaml
+++ b/charts/modernization-api/templates/ingress.yaml
@@ -8,6 +8,8 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: "letsencrypt-production"
     nginx.ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Frame-Options: Allow";
     # nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     # nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     # nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600"

--- a/charts/modernization-api/templates/ingress.yaml
+++ b/charts/modernization-api/templates/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     nginx.ingress.kubernetes.io/service-upstream: "true"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Frame-Options: Allow";
+      more_set_headers "Cross-Origin-Opener-Policy: same-origin";
     # nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     # nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     # nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600"

--- a/charts/nginx-ingress/values.yaml
+++ b/charts/nginx-ingress/values.yaml
@@ -5,6 +5,7 @@ controller:
   config:
     compute-full-forwarded-for: "true"
     use-forwarded-headers: "true"
+    allow-snippet-annotations: "true"
     #proxy-body-size: "0"
   ingressClassResource:
     enabled: true


### PR DESCRIPTION
This fix is required to get reports functioning. Once this is merged, we will need to update all ingress deployments to allow configuration snippets. 