### PR TITLE
Set image tag for nbs-gateway in fts-2

### DIFF
--- a/charts/nbs-gateway/values-fts2.yaml
+++ b/charts/nbs-gateway/values-fts2.yaml
@@ -6,7 +6,7 @@ env: "fts2"
 image:
   repository: ""
   pullPolicy: IfNotPresent
-  tag: 
+  tag: 1.0.1-SNAPSHOT.416e670
 
 gatewayService:
   ports:


### PR DESCRIPTION
Deploys a potential fix to the nbs-gateway container to allow connection to an ALB with security policy: `ELBSecurityPolicy-TLS13-1-2-2021-06`