### PR TITLE
CNFT1-2830 / 2833 new search feature flags

### DIFF
--- a/charts/modernization-api/templates/deployment.yaml
+++ b/charts/modernization-api/templates/deployment.yaml
@@ -50,7 +50,10 @@ spec:
             '--nbs.ui.features.pageBuilder.page.library.enabled={{ .Values.pageBuilder.page.library.enabled }}', 
             '--nbs.ui.features.pageBuilder.page.management.create.enabled={{ .Values.pageBuilder.page.management.create.enabled }}', 
             '--nbs.ui.features.pageBuilder.page.management.edit.enabled={{ .Values.pageBuilder.page.management.edit.enabled }}',
-            '--nbs.ui.settings.smarty.key={{ .Values.ui.smarty.key }}','--nbs.ui.settings.analytics.key={{ .Values.ui.analytics.key }}'
+            '--nbs.ui.features.search.view.enabled={{ ((((.Values).ui).search).view).enabled | default "false" }}',
+            '--nbs.ui.features.search.view.table.enabled={{ (((((.Values).ui).search).view).table).enabled | default "false" }}',
+            '--nbs.ui.settings.smarty.key={{ .Values.ui.smarty.key }}',
+            '--nbs.ui.settings.analytics.key={{ .Values.ui.analytics.key }}'
             ]
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/modernization-api/values-int1.yaml
+++ b/charts/modernization-api/values-int1.yaml
@@ -114,3 +114,6 @@ ui:
     key: ""
   analytics:
     key: ""
+  search:
+    view:
+      enabled: true

--- a/charts/modernization-api/values-int1.yaml
+++ b/charts/modernization-api/values-int1.yaml
@@ -117,3 +117,5 @@ ui:
   search:
     view:
       enabled: true
+      table:
+        enabled: true


### PR DESCRIPTION
Adds feature flags to `modernization-api` to toggle the visibility of the new search screen.  The feature is disabled by default with INT1 values file enabling it for that environment.  This is a non-destructive change that will take affect once the code that honors these feature flags is deployed

Helm chart changes were verified by running `helm template --debug ./modernization-api -f ./modernization-api/values.yaml` and `helm template --debug ./modernization-api -f ./modernization-api/values-int1.yaml ` from the `charts` folder to ensure correct syntax. 