### PR TITLE
OIDC defaults

### DIFF
--- a/charts/modernization-api/templates/deployment.yaml
+++ b/charts/modernization-api/templates/deployment.yaml
@@ -40,7 +40,11 @@ spec:
           command: ['java', '-jar', 'api.jar']
           args: [            
             '--nbs.security.oidc.enabled={{ .Values.oidc.enabled }}',
+            {{- if ((.Values).oidc).uri}}
+            '--nbs.security.oidc.uri={{ .Values.oidc.uri }}',
+            {{- else}}
             '--nbs.security.oidc.uri=https://{{ .Values.ingressHost }}/auth/realms/nbs-users',
+            {{- end }}  
             '--nbs.elasticsearch.url={{ .Values.elasticSearchHost }}', 
             '--spring.datasource.url={{ .Values.jdbc.connectionString }}', 
             '--spring.datasource.username={{ .Values.jdbc.user }}', 

--- a/charts/modernization-api/values.yaml
+++ b/charts/modernization-api/values.yaml
@@ -105,6 +105,8 @@ jdbc:
 # OIDC settings
 oidc:
   enabled: "false"
+  # specifies the uri for the OIDC issuer, defaults to https://ingressHost/auth/realms/nbs-users
+  uri: ""
 
 ui:
   smarty:

--- a/charts/nbs-gateway/templates/deployment.yaml
+++ b/charts/nbs-gateway/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
           #'--spring.cloud.gateway.httpclient.ssl.useInsecureTrustManager=true',
           {{- if eq .Values.oidc.enabled "true" }}        
           '--spring.profiles.include=oidc',
-          {{- if hasKey .Values.oidc "uri"}}
+          {{- if ((.Values).oidc).uri}}
           '--nbs.security.oidc.uri={{ .Values.oidc.uri }}',
           {{- else}}
           '--nbs.security.oidc.uri=https://{{ .Values.ingressHost }}/auth/realms/nbs-users',

--- a/charts/nbs-gateway/templates/deployment.yaml
+++ b/charts/nbs-gateway/templates/deployment.yaml
@@ -24,7 +24,11 @@ spec:
           #'--spring.cloud.gateway.httpclient.ssl.useInsecureTrustManager=true',
           {{- if eq .Values.oidc.enabled "true" }}        
           '--spring.profiles.include=oidc',
+          {{- if hasKey .Values.oidc "uri"}}
+          '--nbs.security.oidc.uri={{ .Values.oidc.uri }}',
+          {{- else}}
           '--nbs.security.oidc.uri=https://{{ .Values.ingressHost }}/auth/realms/nbs-users',
+          {{- end }}         
           '--nbs.security.oidc.client.id={{ .Values.oidc.client.id }}',
           '--nbs.security.oidc.client.secret={{ .Values.oidc.client.secret }}',
           {{- end }}

--- a/charts/nbs-gateway/values.yaml
+++ b/charts/nbs-gateway/values.yaml
@@ -34,7 +34,7 @@ resources: {}
 
 nbsExternalName: app-classic.EXAMPLE_DOMAIN
 
-ingressHost:
+ingressHost: app.EXAMPLE_DOMAIN
 
 modernizationApiHost: "modernization-api.default.svc.cluster.local:8080"
 

--- a/charts/nbs-gateway/values.yaml
+++ b/charts/nbs-gateway/values.yaml
@@ -44,7 +44,7 @@ pagebuilderApiHost: "page-builder-api.default.svc.cluster.local:8095"
 
 # OIDC settings
 oidc:
-  enabled: "false"
+  enabled: "true"
   client:
     id: ""
     secret: ""

--- a/charts/nbs-gateway/values.yaml
+++ b/charts/nbs-gateway/values.yaml
@@ -44,7 +44,9 @@ pagebuilderApiHost: "page-builder-api.default.svc.cluster.local:8095"
 
 # OIDC settings
 oidc:
-  enabled: "true"
+  enabled: "false"
+  # specifies the uri for the OIDC issuer, defaults to https://ingressHost/auth/realms/nbs-users
+  uri: ""
   client:
     id: ""
     secret: ""

--- a/charts/page-builder-api/templates/deployment.yaml
+++ b/charts/page-builder-api/templates/deployment.yaml
@@ -40,7 +40,11 @@ spec:
           command: ['java', '-jar', 'api.jar']
           args: [
             '--nbs.security.oidc.enabled={{ .Values.oidc.enabled }}',
+            {{- if ((.Values).oidc).uri}}
+            '--nbs.security.oidc.uri={{ .Values.oidc.uri }}',
+            {{- else}}
             '--nbs.security.oidc.uri=https://{{ .Values.ingressHost }}/auth/realms/nbs-users',
+            {{- end }}  
             '--spring.datasource.url={{ .Values.jdbc.connectionString }}', 
             '--spring.datasource.username={{ .Values.jdbc.user }}', 
             '--spring.datasource.password={{ .Values.jdbc.password }}', 

--- a/charts/page-builder-api/values.yaml
+++ b/charts/page-builder-api/values.yaml
@@ -71,6 +71,8 @@ autoscaling:
 # OIDC settings
 oidc:
   enabled: "false"
+  # specifies the uri for the OIDC issuer, defaults to https://ingressHost/auth/realms/nbs-users
+  uri: ""
 
 nodeSelector: {}
 


### PR DESCRIPTION
Adds the ability to define an external OIDC issuer uri.  If `oidc.uri` is not present or blank in the values file the `oidc.uri` will be set to `https://{{ .Values.ingressHost }}/auth/realms/nbs-users`