### PR TITLE
Extended patient create feature flag

### DIFF
--- a/charts/modernization-api/templates/deployment.yaml
+++ b/charts/modernization-api/templates/deployment.yaml
@@ -62,6 +62,7 @@ spec:
             '--nbs.ui.features.pageBuilder.page.management.edit.enabled={{ .Values.pageBuilder.page.management.edit.enabled }}',
             '--nbs.ui.features.search.view.enabled={{ ((((.Values).ui).search).view).enabled | default "false" }}',
             '--nbs.ui.features.search.view.table.enabled={{ (((((.Values).ui).search).view).table).enabled | default "false" }}',
+            '--nbs.ui.features.patient.add.extended.enabled={{ (((((.Values).ui).patient).add).extended).enabled | default "false" }}',
             '--nbs.ui.settings.smarty.key={{ .Values.ui.smarty.key }}',
             '--nbs.ui.settings.analytics.key={{ .Values.ui.analytics.key }}'
             ]

--- a/charts/modernization-api/values-int1.yaml
+++ b/charts/modernization-api/values-int1.yaml
@@ -122,3 +122,7 @@ ui:
       enabled: true
       table:
         enabled: true
+  patient:
+    add:
+      extended:
+        enabled: true

--- a/charts/modernization-api/values.yaml
+++ b/charts/modernization-api/values.yaml
@@ -133,4 +133,4 @@ ui:
     add:
       # when enabled, allows user to create a patient with all available demographic data
       extended:
-        enabled: true
+        enabled: false

--- a/charts/modernization-api/values.yaml
+++ b/charts/modernization-api/values.yaml
@@ -118,6 +118,7 @@ oidc:
   # specifies the uri for the OIDC issuer, defaults to https://ingressHost/auth/realms/nbs-users
   uri: ""
 
+# feature flag configurations for modernized ui
 ui:
   smarty:
     key: ""
@@ -127,4 +128,9 @@ ui:
     view:
       enabled: true
       table:
+        enabled: true
+  patient:
+    add:
+      # when enabled, allows user to create a patient with all available demographic data
+      extended:
         enabled: true


### PR DESCRIPTION
Passes the extended patient create feature flag to the modernization-api container. 

Default value will be false.

Set value to true in the int1 environment