### PR TITLE
CNDIT-264: Making the RTR Kafka sink connector values-dts1.yaml database url on par with the Demo to replicate a deployment issue.

### DIFF
--- a/charts/kafka-connect-sink/values-dts1.yaml
+++ b/charts/kafka-connect-sink/values-dts1.yaml
@@ -41,7 +41,7 @@ sqlServerConnector: {
     "connector.class": "io.confluent.connect.jdbc.JdbcSinkConnector",
     "tasks.max": "1",
     "offset.flush.interval.ms": "2000",
-    "connection.url": "jdbc:sqlserver://nbs-db.private-dts1.nbspreview.com:1433;databaseName=rdb_modern;encrypt=true;trustServerCertificate=true;",
+    "connection.url": "jdbc:sqlserver://nbs-db.EXAMPLE_FIXME.nbspreview.com:1433;databaseName=rdb_modern;encrypt=true;trustServerCertificate=true;",
     "connection.user": "",
     "connection.password": "",
     "connection.pool.min_size": "5",


### PR DESCRIPTION
CNDIT-264: Making the RTR Kafka sink connector values-dts1.yaml database url on par with the Demo to replicate a deployment issue.