### PR TITLE
[CNFT1-3395] Adds feature flag for modernized basic patient add

### DIFF
--- a/charts/modernization-api/templates/deployment.yaml
+++ b/charts/modernization-api/templates/deployment.yaml
@@ -61,6 +61,7 @@ spec:
             '--nbs.ui.features.search.events.enabled={{ ((((.Values).ui).search).events).enabled | default "true" }}',
             '--nbs.ui.features.search.investigations.enabled={{ ((((.Values).ui).search).investigations).enabled | default "false"}}',
             '--nbs.ui.features.search.laboratoryReports.enabled={{ ((((.Values).ui).search).laboratoryReports).enabled | default "false"}}',
+            '--nbs.ui.features.patient.add.enabled={{ ((((.Values).ui).patient).add).enabled | default "false" }}',
             '--nbs.ui.features.patient.add.extended.enabled={{ (((((.Values).ui).patient).add).extended).enabled | default "false" }}',
             '--nbs.ui.settings.smarty.key={{ (((.Values).ui).smarty).key }}',
             '--nbs.ui.settings.analytics.host={{ (((.Values).ui).analytics).host }}',

--- a/charts/modernization-api/values-int1.yaml
+++ b/charts/modernization-api/values-int1.yaml
@@ -117,5 +117,6 @@ ui:
         enabled: true
   patient:
     add:
+      enabled: true
       extended:
         enabled: true

--- a/charts/modernization-api/values.yaml
+++ b/charts/modernization-api/values.yaml
@@ -132,6 +132,8 @@ ui:
         enabled: true
   patient:
     add:
-      # when enabled, allows user to create a patient with all available demographic data
+      # when enabled, allows access to the modernized New patient feature to create a patient with basic demographic data
+      enabled: true
+      # when enabled, allows access to the modernized New patient - extended feature to create a patient with all available demographic data
       extended:
         enabled: true


### PR DESCRIPTION
Adds a configurable feature flag for the updated New patient creation experience.  The `patient.add.enabled` flag is disabled by default and enabled for the INT1 environment.