### PR TITLE
[CNFT1-3519] patient profile feature flag

### DIFF
--- a/charts/modernization-api/templates/deployment.yaml
+++ b/charts/modernization-api/templates/deployment.yaml
@@ -60,9 +60,10 @@ spec:
             '--nbs.ui.features.search.view.table.enabled={{ (((((.Values).ui).search).view).table).enabled | default "false" }}',
             '--nbs.ui.features.search.events.enabled={{ ((((.Values).ui).search).events).enabled | default "true" }}',
             '--nbs.ui.features.search.investigations.enabled={{ ((((.Values).ui).search).investigations).enabled | default "false"}}',
-            '--nbs.ui.features.search.laboratoryReports.enabled={{ ((((.Values).ui).search).laboratoryReports).enabled | default "false"}}',
+            '--nbs.ui.features.search.laboratoryReports.enabled={{ ((((.Values).ui).search).laboratoryReports).enabled | default "false"}}',            
             '--nbs.ui.features.patient.add.enabled={{ ((((.Values).ui).patient).add).enabled | default "false" }}',
             '--nbs.ui.features.patient.add.extended.enabled={{ (((((.Values).ui).patient).add).extended).enabled | default "false" }}',
+            '--nbs.ui.features.patient.profile.enabled={{ ((((.Values).ui).patient).profile).enabled | default "false" }}',
             '--nbs.ui.settings.smarty.key={{ (((.Values).ui).smarty).key }}',
             '--nbs.ui.settings.analytics.host={{ (((.Values).ui).analytics).host }}',
             '--nbs.ui.settings.analytics.key={{ (((.Values).ui).analytics).key }}'

--- a/charts/modernization-api/values.yaml
+++ b/charts/modernization-api/values.yaml
@@ -131,9 +131,12 @@ ui:
       table:
         enabled: true
   patient:
-    add:
-      # when enabled, allows access to the modernized New patient feature to create a patient with basic demographic data
+    profile:
+      # Enables access to the modernized patient profile
       enabled: false
-      # when enabled, allows access to the modernized New patient - extended feature to create a patient with all available demographic data
+    add:
+      # Enables access to the modernized New patient feature to create a patient with basic demographic data
+      enabled: false
+      # Enables access to the modernized New patient - extended feature to create a patient with all available demographic data
       extended:
         enabled: true

--- a/charts/nbs-gateway/templates/deployment.yaml
+++ b/charts/nbs-gateway/templates/deployment.yaml
@@ -37,6 +37,7 @@ spec:
           '--nbs.gateway.modernization.service={{ .Values.modernizationApiHost }}',
           '--nbs.gateway.patient.search.service={{ .Values.modernizationApiHost }}',
           '--nbs.gateway.patient.profile.service={{ .Values.modernizationApiHost }}',
+          '--nbs.gateway.patient.profile.enabled={{ (((.Values).patient).profile).enabled | default "false" }}',
           '--nbs.gateway.pagebuilder.service={{ .Values.pagebuilderApiHost }}', 
           '--nbs.gateway.pagebuilder.enabled={{ .Values.pageBuilder.enabled }}', 
           '--nbs.gateway.pagebuilder.page.library.enabled={{ .Values.pageBuilder.page.library.enabled }}',

--- a/charts/nbs-gateway/values.yaml
+++ b/charts/nbs-gateway/values.yaml
@@ -21,10 +21,17 @@ gatewayService:
 kubernetesClusterDomain: cluster.local
 
 landing:
+  # Specifies the path the user is redirected to when navigating to the root
   base: "/welcome"
 
 welcome:
+  # Enables routing to the NBS7 welcome page
   enabled: "true"
+
+patient:
+  profile:
+    # Enables routing from NBS6 pages to the Patient Profile
+    enabled: false
 
 pageBuilder:
   enabled: "true"


### PR DESCRIPTION
Adds feature flags for the modernized patient profile.  

When the `patient.profile.enabled` feature flag is enabled for the `nbs-gateway` any routes that lead to the NBS6 patient profile are replaced with redirects to the modernized patient profile.  The flag is defaulted to `false`.

When the `patient.profile.enabled` feature flag is enabled for the `modernization-api` the modernized patient profile is shown when patient search results are clicked or after a new patient is added.  The flag is defaulted to `false`.

The code changes that use these flags has not been merged and will have no affect until those changes are deployed.  There will be a follow up PR to enable these flags in the INT1 environment.