### PR TITLE
moves the default value of the analytics host to helm charts

### DIFF
--- a/charts/modernization-api/values.yaml
+++ b/charts/modernization-api/values.yaml
@@ -111,8 +111,8 @@ ui:
     # The embedded API key, when blank the Smarty API will not be invoked.
     key:
   analytics:
-    # The host name of the PostHog server to send analytics to, when blank it will default to https://us.posthog.com
-    host:
+    # The host name of the PostHog server to send analytics to
+    host: "https://us.i.posthog.com"
     # The PostHog project key to associate frontend analytics with, when blank analytics will not be enabled
     key:
   # feature flag configurations for modernized ui


### PR DESCRIPTION
I am removing the default values of properties that deal with external  services from the `modernization-api` configuration so that they are in one place in the helm charts.  

The change from `https://us.posthog.com` to `https://us.i.posthog.com` is intentional, the host name for capturing events was changed in the documentation.