### PR TITLE
added placeholder for srte in data-processing-service

### DIFF
--- a/charts/data-processing-service/values.yaml
+++ b/charts/data-processing-service/values.yaml
@@ -76,3 +76,12 @@ java:
     xms: "1024m"
     xmx: "2048m"
 
+# FIXME: the remaining values will be used in next release, not used for
+# 7.8.0 - cmoss
+dataingestion:
+  uri: "EXAMPLE_DI_URI"
+
+keycloak:
+  srte:
+    clientId: "EXAMPLE_SRTE_CLIENT_ID"
+    clientSecret: "EXAMPLE_SRTE_CLIENT_SECRET"


### PR DESCRIPTION
this should prevent error on helm install and these values will be needed in next release