### PR TITLE
[CNDE-2077] RTR services time zone updated to Mountain Time

### DIFF
--- a/charts/debezium-srte/values-azure.yaml
+++ b/charts/debezium-srte/values-azure.yaml
@@ -89,7 +89,7 @@ connect:
     - name: NAME
       value: "debezium-connector-v010925"
     - name: TZ
-      value: "America/Denver"
+      value: "UTC"
 
 ui:
   enabled: false
@@ -126,4 +126,6 @@ ui:
   env:
     - name: KAFKA_CONNECT_URIS
       value: "http://debezium-connect:8083"
+    - name: TZ
+      value: "UTC"
 

--- a/charts/debezium-srte/values-azure.yaml
+++ b/charts/debezium-srte/values-azure.yaml
@@ -32,7 +32,7 @@ connect:
       memory: 1Gi
 
   properties:
-    group_id: "debezium-connector-v111224"
+    group_id: "debezium-connector-v010925"
     topics_basename: "debezium-connector"
     default_replication_factor: 2
     default_partitions: 10
@@ -42,7 +42,7 @@ connect:
     sql_server_agent_status: "select dbo.IsSqlAgentRunning()"
 
   sqlserverconnector: {
-    "name": "debezium-connector-v111224",
+    "name": "debezium-connector-v010925",
     "config": {
       "connector.class": "io.debezium.connector.sqlserver.SqlServerConnector",
       "database.hostname": "tf-cdc-nbs6-sql-managed-instance.cdf5734b998e.database.windows.net",
@@ -87,7 +87,9 @@ connect:
     - name: KAFKA_LOG4J_OPTS
       value: "-Dlog4j.configuration=file:/kafka/config/log4j.properties"
     - name: NAME
-      value: "debezium-connector-v111224"
+      value: "debezium-connector-v010925"
+    - name: TZ
+      value: "America/Denver"
 
 ui:
   enabled: false

--- a/charts/debezium-srte/values-dts1.yaml
+++ b/charts/debezium-srte/values-dts1.yaml
@@ -31,7 +31,7 @@ connect:
       memory: 1Gi
 
   properties:
-    group_id: "debezium-connector-v111224"
+    group_id: "debezium-connector-v010925"
     topics_basename: "debezium-connector"
     default_replication_factor: 2
     default_partitions: 10
@@ -41,7 +41,7 @@ connect:
     bootstrap_server: "b-1.nrtreporting.rx5iwx.c5.kafka.us-east-1.amazonaws.com:9092,b-2.nrtreporting.rx5iwx.c5.kafka.us-east-1.amazonaws.com:9092"
 
   sqlserverconnector: {
-    "name": "debezium-connector-v111224",
+    "name": "debezium-connector-v010925",
     "config": {
       "connector.class": "io.debezium.connector.sqlserver.SqlServerConnector",
       "database.hostname": "nbs-db.private-dts1.nbspreview.com",
@@ -86,7 +86,9 @@ connect:
     - name: KAFKA_LOG4J_OPTS
       value: "-Dlog4j.configuration=file:/kafka/config/log4j.properties"
     - name: NAME
-      value: "debezium-connector-v111224"
+      value: "debezium-connector-v010925"
+    - name: TZ
+      value: "America/Denver"
 
 ui:
   enabled: false

--- a/charts/debezium-srte/values-dts1.yaml
+++ b/charts/debezium-srte/values-dts1.yaml
@@ -88,7 +88,7 @@ connect:
     - name: NAME
       value: "debezium-connector-v010925"
     - name: TZ
-      value: "America/Denver"
+      value: "UTC"
 
 ui:
   enabled: false
@@ -125,4 +125,6 @@ ui:
   env:
     - name: KAFKA_CONNECT_URIS
       value: "http://debezium-connect:8083"
+    - name: TZ
+      value: "UTC"
 

--- a/charts/debezium-srte/values-feature.yaml
+++ b/charts/debezium-srte/values-feature.yaml
@@ -31,7 +31,7 @@ connect:
       memory: 1Gi
 
   properties:
-    group_id: "debezium-connector-v111224"
+    group_id: "debezium-connector-v010925"
     topics_basename: "debezium-connector"
     default_replication_factor: 2
     default_partitions: 10
@@ -41,7 +41,7 @@ connect:
     bootstrap_server: "b-2.cdcnbsfeaturedevelopme.f4c8vq.c9.kafka.us-east-1.amazonaws.com:9092,b-1.cdcnbsfeaturedevelopme.f4c8vq.c9.kafka.us-east-1.amazonaws.com:9092"
 
   sqlserverconnector: {
-    "name": "debezium-connector-v111224",
+    "name": "debezium-connector-v010925",
     "config": {
       "connector.class": "io.debezium.connector.sqlserver.SqlServerConnector",
       "database.hostname": "nbs-db.private-feature.nbspreview.com",
@@ -86,7 +86,9 @@ connect:
     - name: KAFKA_LOG4J_OPTS
       value: "-Dlog4j.configuration=file:/kafka/config/log4j.properties"
     - name: NAME
-      value: "debezium-connector-v111224"
+      value: "debezium-connector-v010925"
+    - name: TZ
+      value: "America/Denver"
 
 ui:
   enabled: false

--- a/charts/debezium-srte/values-feature.yaml
+++ b/charts/debezium-srte/values-feature.yaml
@@ -88,7 +88,7 @@ connect:
     - name: NAME
       value: "debezium-connector-v010925"
     - name: TZ
-      value: "America/Denver"
+      value: "UTC"
 
 ui:
   enabled: false
@@ -125,4 +125,6 @@ ui:
   env:
     - name: KAFKA_CONNECT_URIS
       value: "http://debezium-connect:8083"
+    - name: TZ
+      value: "UTC"
 

--- a/charts/debezium-srte/values-int1.yaml
+++ b/charts/debezium-srte/values-int1.yaml
@@ -31,7 +31,7 @@ connect:
       memory: 1Gi
 
   properties:
-    group_id: "debezium-connector-v111224"
+    group_id: "debezium-connector-v010925"
     topics_basename: "debezium-connector"
     default_replication_factor: 2
     default_partitions: 10
@@ -41,7 +41,7 @@ connect:
     bootstrap_server: "b-2.cdcnbsint1developmentm.8u6ipl.c2.kafka.us-east-1.amazonaws.com:9092,b-1.cdcnbsint1developmentm.8u6ipl.c2.kafka.us-east-1.amazonaws.com:9092"
 
   sqlserverconnector: {
-    "name": "debezium-connector-v111224",
+    "name": "debezium-connector-v010925",
     "config": {
       "connector.class": "io.debezium.connector.sqlserver.SqlServerConnector",
       "database.hostname": "nbs-db.private-int1.nbspreview.com",
@@ -86,7 +86,7 @@ connect:
     - name: KAFKA_LOG4J_OPTS
       value: "-Dlog4j.configuration=file:/kafka/config/log4j.properties"
     - name: NAME
-      value: "debezium-connector-v111224"
+      value: "debezium-connector-v010925"
 
 ui:
   enabled: false
@@ -123,4 +123,6 @@ ui:
   env:
     - name: KAFKA_CONNECT_URIS
       value: "http://debezium-connect:8083"
+    - name: TZ
+      value: "America/Denver"
 

--- a/charts/debezium-srte/values-int1.yaml
+++ b/charts/debezium-srte/values-int1.yaml
@@ -87,6 +87,8 @@ connect:
       value: "-Dlog4j.configuration=file:/kafka/config/log4j.properties"
     - name: NAME
       value: "debezium-connector-v010925"
+    - name: TZ
+      value: "UTC"
 
 ui:
   enabled: false
@@ -124,5 +126,5 @@ ui:
     - name: KAFKA_CONNECT_URIS
       value: "http://debezium-connect:8083"
     - name: TZ
-      value: "America/Denver"
+      value: "UTC"
 

--- a/charts/debezium-srte/values-test1.yaml
+++ b/charts/debezium-srte/values-test1.yaml
@@ -31,7 +31,7 @@ connect:
       memory: 1Gi
 
   properties:
-    group_id: "debezium-connector-v111224"
+    group_id: "debezium-connector-v010925"
     topics_basename: "debezium-connector"
     default_replication_factor: 2
     default_partitions: 10
@@ -41,7 +41,7 @@ connect:
     bootstrap_server: "b-1.cdcnbstestdevelopment.toyoo7.c10.kafka.us-east-1.amazonaws.com:9092,b-2.cdcnbstestdevelopment.toyoo7.c10.kafka.us-east-1.amazonaws.com:9092"
 
   sqlserverconnector: {
-    "name": "debezium-connector-v111224",
+    "name": "debezium-connector-v010925",
     "config": {
       "connector.class": "io.debezium.connector.sqlserver.SqlServerConnector",
       "database.hostname": "nbs-db.private-test.nbspreview.com",
@@ -86,7 +86,9 @@ connect:
     - name: KAFKA_LOG4J_OPTS
       value: "-Dlog4j.configuration=file:/kafka/config/log4j.properties"
     - name: NAME
-      value: "debezium-connector-v111224"
+      value: "debezium-connector-v010925"
+    - name: TZ
+      value: "America/Denver"
 
 ui:
   enabled: false

--- a/charts/debezium-srte/values-test1.yaml
+++ b/charts/debezium-srte/values-test1.yaml
@@ -88,7 +88,7 @@ connect:
     - name: NAME
       value: "debezium-connector-v010925"
     - name: TZ
-      value: "America/Denver"
+      value: "UTC"
 
 ui:
   enabled: false
@@ -125,4 +125,6 @@ ui:
   env:
     - name: KAFKA_CONNECT_URIS
       value: "http://debezium-connect:8083"
+    - name: TZ
+      value: "UTC"
 

--- a/charts/debezium-srte/values.yaml
+++ b/charts/debezium-srte/values.yaml
@@ -90,7 +90,7 @@ connect:
     - name: NAME
       value: "debezium-connector-v010925"
     - name: TZ
-      value: "America/Denver"
+      value: "UTC"
 
 ui:
   enabled: false
@@ -128,4 +128,6 @@ ui:
   env:
     - name: KAFKA_CONNECT_URIS
       value: "http://debezium-connect:8083"
+    - name: TZ
+      value: "UTC"
 

--- a/charts/debezium-srte/values.yaml
+++ b/charts/debezium-srte/values.yaml
@@ -31,7 +31,7 @@ connect:
       memory: 1Gi
 
   properties:
-    group_id: "debezium-connector-v111224"
+    group_id: "debezium-connector-v010925"
     topics_basename: "debezium-connector"
     default_replication_factor: 2
     default_partitions: 10
@@ -43,7 +43,7 @@ connect:
   # dbserver: "EXAMPLE_DB_ENDPOINT"
   
   sqlserverconnector: {
-    "name": "debezium-connector-v111224",
+    "name": "debezium-connector-v010925",
     "config": {
       "connector.class": "io.debezium.connector.sqlserver.SqlServerConnector",
       "database.hostname": "nbs-db.private-EXAMPLE_DOMAIN",
@@ -88,7 +88,9 @@ connect:
     - name: KAFKA_LOG4J_OPTS
       value: "-Dlog4j.configuration=file:/kafka/config/log4j.properties"
     - name: NAME
-      value: "debezium-connector-v111224"
+      value: "debezium-connector-v010925"
+    - name: TZ
+      value: "America/Denver"
 
 ui:
   enabled: false

--- a/charts/debezium/values-azure.yaml
+++ b/charts/debezium/values-azure.yaml
@@ -89,7 +89,7 @@ connect:
     - name: NAME
       value: "debezium-connector-v010925"
     - name: TZ
-      value: "America/Denver"
+      value: "UTC"
 
 ui:
   enabled: false
@@ -126,4 +126,6 @@ ui:
   env:
     - name: KAFKA_CONNECT_URIS
       value: "http://debezium-connect:8083"
+    - name: TZ
+      value: "UTC"
 

--- a/charts/debezium/values-azure.yaml
+++ b/charts/debezium/values-azure.yaml
@@ -32,7 +32,7 @@ connect:
       memory: 1Gi
 
   properties:
-    group_id: "debezium-connector-v071524"
+    group_id: "debezium-connector-v010925"
     topics_basename: "debezium-connector"
     default_replication_factor: 2
     default_partitions: 10
@@ -42,7 +42,7 @@ connect:
     sql_server_agent_status: "select dbo.IsSqlAgentRunning()"
 
   sqlserverconnector: {
-    "name": "debezium-connector-v071524",
+    "name": "debezium-connector-v010925",
     "config": {
       "connector.class": "io.debezium.connector.sqlserver.SqlServerConnector",
       "database.hostname": "tf-cdc-nbs6-sql-managed-instance.cdf5734b998e.database.windows.net",
@@ -87,7 +87,9 @@ connect:
     - name: KAFKA_LOG4J_OPTS
       value: "-Dlog4j.configuration=file:/kafka/config/log4j.properties"
     - name: NAME
-      value: "debezium-connector-v071524"
+      value: "debezium-connector-v010925"
+    - name: TZ
+      value: "America/Denver"
 
 ui:
   enabled: false

--- a/charts/debezium/values-dts1.yaml
+++ b/charts/debezium/values-dts1.yaml
@@ -89,7 +89,7 @@ connect:
     - name: NAME
       value: "debezium-connector-v010925"
     - name: TZ
-      value: "America/Denver"
+      value: "UTC"
 
 ui:
   enabled: false
@@ -126,4 +126,6 @@ ui:
   env:
     - name: KAFKA_CONNECT_URIS
       value: "http://debezium-connect:8083"
+    - name: TZ
+      value: "UTC"
 

--- a/charts/debezium/values-dts1.yaml
+++ b/charts/debezium/values-dts1.yaml
@@ -31,7 +31,7 @@ connect:
       memory: 1Gi
 
   properties:
-    group_id: "debezium-connector-v071524"
+    group_id: "debezium-connector-v010925"
     topics_basename: "debezium-connector"
     default_replication_factor: 2
     default_partitions: 10
@@ -41,7 +41,7 @@ connect:
     bootstrap_server: "b-1.nrtreporting.rx5iwx.c5.kafka.us-east-1.amazonaws.com:9092,b-2.nrtreporting.rx5iwx.c5.kafka.us-east-1.amazonaws.com:9092"
 
   sqlserverconnector: {
-    "name": "debezium-connector-v071524",
+    "name": "debezium-connector-v010925",
     "config": {
       "connector.class": "io.debezium.connector.sqlserver.SqlServerConnector",
       "database.hostname": "nbs-db.private-dts1.nbspreview.com",
@@ -87,7 +87,9 @@ connect:
     - name: KAFKA_LOG4J_OPTS
       value: "-Dlog4j.configuration=file:/kafka/config/log4j.properties"
     - name: NAME
-      value: "debezium-connector-v071524"
+      value: "debezium-connector-v010925"
+    - name: TZ
+      value: "America/Denver"
 
 ui:
   enabled: false

--- a/charts/debezium/values-feature.yaml
+++ b/charts/debezium/values-feature.yaml
@@ -31,7 +31,7 @@ connect:
       memory: 1Gi
 
   properties:
-    group_id: "debezium-connector-v071524"
+    group_id: "debezium-connector-v010925"
     topics_basename: "debezium-connector"
     default_replication_factor: 2
     default_partitions: 10
@@ -41,7 +41,7 @@ connect:
     bootstrap_server: "b-2.cdcnbsfeaturedevelopme.f4c8vq.c9.kafka.us-east-1.amazonaws.com:9092,b-1.cdcnbsfeaturedevelopme.f4c8vq.c9.kafka.us-east-1.amazonaws.com:9092"
 
   sqlserverconnector: {
-    "name": "debezium-connector-v071524",
+    "name": "debezium-connector-v010925",
     "config": {
       "connector.class": "io.debezium.connector.sqlserver.SqlServerConnector",
       "database.hostname": "nbs-db.private-feature.nbspreview.com",
@@ -87,7 +87,7 @@ connect:
     - name: KAFKA_LOG4J_OPTS
       value: "-Dlog4j.configuration=file:/kafka/config/log4j.properties"
     - name: NAME
-      value: "debezium-connector-v071524"
+      value: "debezium-connector-v010925"
 
 ui:
   enabled: false
@@ -124,4 +124,6 @@ ui:
   env:
     - name: KAFKA_CONNECT_URIS
       value: "http://debezium-connect:8083"
+    - name: TZ
+      value: "America/Denver"
 

--- a/charts/debezium/values-feature.yaml
+++ b/charts/debezium/values-feature.yaml
@@ -88,6 +88,8 @@ connect:
       value: "-Dlog4j.configuration=file:/kafka/config/log4j.properties"
     - name: NAME
       value: "debezium-connector-v010925"
+    - name: TZ
+      value: "UTC"
 
 ui:
   enabled: false
@@ -125,5 +127,5 @@ ui:
     - name: KAFKA_CONNECT_URIS
       value: "http://debezium-connect:8083"
     - name: TZ
-      value: "America/Denver"
+      value: "UTC"
 

--- a/charts/debezium/values-int1.yaml
+++ b/charts/debezium/values-int1.yaml
@@ -89,7 +89,7 @@ connect:
     - name: NAME
       value: "debezium-connector-v010925"
     - name: TZ
-      value: "America/Denver"
+      value: "UTC"
 
 ui:
   enabled: false
@@ -126,4 +126,6 @@ ui:
   env:
     - name: KAFKA_CONNECT_URIS
       value: "http://debezium-connect:8083"
+    - name: TZ
+      value: "UTC"
 

--- a/charts/debezium/values-int1.yaml
+++ b/charts/debezium/values-int1.yaml
@@ -31,7 +31,7 @@ connect:
       memory: 1Gi
 
   properties:
-    group_id: "debezium-connector-v071524"
+    group_id: "debezium-connector-v010925"
     topics_basename: "debezium-connector"
     default_replication_factor: 2
     default_partitions: 10
@@ -41,7 +41,7 @@ connect:
     bootstrap_server: "b-2.cdcnbsint1developmentm.8u6ipl.c2.kafka.us-east-1.amazonaws.com:9092,b-1.cdcnbsint1developmentm.8u6ipl.c2.kafka.us-east-1.amazonaws.com:9092"
 
   sqlserverconnector: {
-    "name": "debezium-connector-v071524",
+    "name": "debezium-connector-v010925",
     "config": {
       "connector.class": "io.debezium.connector.sqlserver.SqlServerConnector",
       "database.hostname": "nbs-db.private-int1.nbspreview.com",
@@ -87,7 +87,9 @@ connect:
     - name: KAFKA_LOG4J_OPTS
       value: "-Dlog4j.configuration=file:/kafka/config/log4j.properties"
     - name: NAME
-      value: "debezium-connector-v071524"
+      value: "debezium-connector-v010925"
+    - name: TZ
+      value: "America/Denver"
 
 ui:
   enabled: false

--- a/charts/debezium/values-test1.yaml
+++ b/charts/debezium/values-test1.yaml
@@ -89,7 +89,7 @@ connect:
     - name: NAME
       value: "debezium-connector-v010925"
     - name: TZ
-      value: "America/Denver"
+      value: "UTC"
 
 ui:
   enabled: false
@@ -126,4 +126,6 @@ ui:
   env:
     - name: KAFKA_CONNECT_URIS
       value: "http://debezium-connect:8083"
+    - name: TZ
+      value: "UTC"
 

--- a/charts/debezium/values-test1.yaml
+++ b/charts/debezium/values-test1.yaml
@@ -31,7 +31,7 @@ connect:
       memory: 1Gi
 
   properties:
-    group_id: "debezium-connector-v071524"
+    group_id: "debezium-connector-v010925"
     topics_basename: "debezium-connector"
     default_replication_factor: 2
     default_partitions: 10
@@ -41,7 +41,7 @@ connect:
     bootstrap_server: "b-1.cdcnbstestdevelopment.toyoo7.c10.kafka.us-east-1.amazonaws.com:9092,b-2.cdcnbstestdevelopment.toyoo7.c10.kafka.us-east-1.amazonaws.com:9092"
 
   sqlserverconnector: {
-    "name": "debezium-connector-v071524",
+    "name": "debezium-connector-v010925",
     "config": {
       "connector.class": "io.debezium.connector.sqlserver.SqlServerConnector",
       "database.hostname": "nbs-db.private-test.nbspreview.com",
@@ -87,7 +87,9 @@ connect:
     - name: KAFKA_LOG4J_OPTS
       value: "-Dlog4j.configuration=file:/kafka/config/log4j.properties"
     - name: NAME
-      value: "debezium-connector-v071524"
+      value: "debezium-connector-v010925"
+    - name: TZ
+      value: "America/Denver"
 
 ui:
   enabled: false

--- a/charts/debezium/values.yaml
+++ b/charts/debezium/values.yaml
@@ -91,7 +91,7 @@ connect:
     - name: NAME
       value: "debezium-connector-v010925"
     - name: TZ
-      value: "America/Denver"
+      value: "UTC"
 
 ui:
   enabled: false
@@ -128,4 +128,6 @@ ui:
   env:
     - name: KAFKA_CONNECT_URIS
       value: "http://debezium-connect:8083"
+    - name: TZ
+      value: "UTC"
 

--- a/charts/debezium/values.yaml
+++ b/charts/debezium/values.yaml
@@ -31,7 +31,7 @@ connect:
       memory: 1Gi
 
   properties:
-    group_id: "debezium-connector-v071524"
+    group_id: "debezium-connector-v010925"
     topics_basename: "debezium-connector"
     default_replication_factor: 2
     default_partitions: 10
@@ -43,7 +43,7 @@ connect:
   # dbserver: "EXAMPLE_DB_ENDPOINT"
   
   sqlserverconnector: {
-    "name": "debezium-connector-v071524",
+    "name": "debezium-connector-v010925",
     "config": {
       "connector.class": "io.debezium.connector.sqlserver.SqlServerConnector",
       "database.hostname": "nbs-db.private-EXAMPLE_DOMAIN",
@@ -89,7 +89,9 @@ connect:
     - name: KAFKA_LOG4J_OPTS
       value: "-Dlog4j.configuration=file:/kafka/config/log4j.properties"
     - name: NAME
-      value: "debezium-connector-v071524"
+      value: "debezium-connector-v010925"
+    - name: TZ
+      value: "America/Denver"
 
 ui:
   enabled: false

--- a/charts/investigation-reporting-service/templates/deployment.yaml
+++ b/charts/investigation-reporting-service/templates/deployment.yaml
@@ -52,6 +52,8 @@ spec:
               value: {{ .Values.rdb.dburl }}
             - name: PHC_DM_ENABLE
               value: {{ .Values.phcDatamartEnable }}
+            - name: TZ
+              value: {{ .Values.timezone }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/investigation-reporting-service/values-dts1.yaml
+++ b/charts/investigation-reporting-service/values-dts1.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "dts1"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/investigation-reporting-service/values-dts1.yaml
+++ b/charts/investigation-reporting-service/values-dts1.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "dts1"
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/investigation-reporting-service/values-feature.yaml
+++ b/charts/investigation-reporting-service/values-feature.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "feature"
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/investigation-reporting-service/values-feature.yaml
+++ b/charts/investigation-reporting-service/values-feature.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "feature"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/investigation-reporting-service/values-int1.yaml
+++ b/charts/investigation-reporting-service/values-int1.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "int1"
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/investigation-reporting-service/values-int1.yaml
+++ b/charts/investigation-reporting-service/values-int1.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "int1"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/investigation-reporting-service/values-test1.yaml
+++ b/charts/investigation-reporting-service/values-test1.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "test"
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/investigation-reporting-service/values-test1.yaml
+++ b/charts/investigation-reporting-service/values-test1.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "test"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/investigation-reporting-service/values.yaml
+++ b/charts/investigation-reporting-service/values.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "prod"
+timezone: "America/Denver"
 
 image:
   #repository: "public.ecr.aws/o1z7u2g7/cdc-nbs-modernization/data-reporting-service/investigation-reporting-service"

--- a/charts/investigation-reporting-service/values.yaml
+++ b/charts/investigation-reporting-service/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "prod"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   #repository: "public.ecr.aws/o1z7u2g7/cdc-nbs-modernization/data-reporting-service/investigation-reporting-service"

--- a/charts/ldfdata-reporting-service/templates/deployment.yaml
+++ b/charts/ldfdata-reporting-service/templates/deployment.yaml
@@ -48,6 +48,8 @@ spec:
               value: {{ .Values.log.path }}
             - name: DB_ODSE_URL
               value: {{ .Values.odse.dburl }}
+            - name: TZ
+              value: {{ .Values.timezone }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/ldfdata-reporting-service/values-dts1.yaml
+++ b/charts/ldfdata-reporting-service/values-dts1.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "dts1"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/ldfdata-reporting-service/values-dts1.yaml
+++ b/charts/ldfdata-reporting-service/values-dts1.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "dts1"
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/ldfdata-reporting-service/values-feature.yaml
+++ b/charts/ldfdata-reporting-service/values-feature.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "feature"
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/ldfdata-reporting-service/values-feature.yaml
+++ b/charts/ldfdata-reporting-service/values-feature.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "feature"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/ldfdata-reporting-service/values-int1.yaml
+++ b/charts/ldfdata-reporting-service/values-int1.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "int1"
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/ldfdata-reporting-service/values-int1.yaml
+++ b/charts/ldfdata-reporting-service/values-int1.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "int1"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/ldfdata-reporting-service/values-test1.yaml
+++ b/charts/ldfdata-reporting-service/values-test1.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "test"
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/ldfdata-reporting-service/values-test1.yaml
+++ b/charts/ldfdata-reporting-service/values-test1.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "test"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/ldfdata-reporting-service/values.yaml
+++ b/charts/ldfdata-reporting-service/values.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "prod"
+timezone: "America/Denver"
 
 image:
   #repository: "public.ecr.aws/o1z7u2g7/cdc-nbs-modernization/data-reporting-service/ldfdata-reporting-service"

--- a/charts/ldfdata-reporting-service/values.yaml
+++ b/charts/ldfdata-reporting-service/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "prod"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   #repository: "public.ecr.aws/o1z7u2g7/cdc-nbs-modernization/data-reporting-service/ldfdata-reporting-service"

--- a/charts/liquibase/templates/deployment.yaml
+++ b/charts/liquibase/templates/deployment.yaml
@@ -37,6 +37,9 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          env:
+            - name: TZ
+              value: {{ .Values.timezone }}
           command:
             - "bash"
             - "-c"

--- a/charts/liquibase/values-dts1.yaml
+++ b/charts/liquibase/values-dts1.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "dts1"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/liquibase/values-dts1.yaml
+++ b/charts/liquibase/values-dts1.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "dts1"
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/liquibase/values-feature.yaml
+++ b/charts/liquibase/values-feature.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "feature"
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/liquibase/values-feature.yaml
+++ b/charts/liquibase/values-feature.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "feature"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/liquibase/values-int1.yaml
+++ b/charts/liquibase/values-int1.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "int1"
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/liquibase/values-int1.yaml
+++ b/charts/liquibase/values-int1.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "int1"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/liquibase/values-test1.yaml
+++ b/charts/liquibase/values-test1.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "test"
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/liquibase/values-test1.yaml
+++ b/charts/liquibase/values-test1.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "test"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/liquibase/values.yaml
+++ b/charts/liquibase/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "prod"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   #repository: "public.ecr.aws/o1z7u2g7/cdc-nbs-modernization/liquibase-service"

--- a/charts/liquibase/values.yaml
+++ b/charts/liquibase/values.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "prod"
+timezone: "America/Denver"
 
 image:
   #repository: "public.ecr.aws/o1z7u2g7/cdc-nbs-modernization/liquibase-service"

--- a/charts/observation-reporting-service/templates/deployment.yaml
+++ b/charts/observation-reporting-service/templates/deployment.yaml
@@ -48,6 +48,8 @@ spec:
               value: {{ .Values.log.path }}
             - name: DB_ODSE_URL
               value: {{ .Values.odse.dburl }}
+            - name: TZ
+              value: {{ .Values.timezone }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/observation-reporting-service/values-dts1.yaml
+++ b/charts/observation-reporting-service/values-dts1.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "dts1"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/observation-reporting-service/values-dts1.yaml
+++ b/charts/observation-reporting-service/values-dts1.yaml
@@ -6,7 +6,7 @@ timezone: "America/Denver"
 image:
   repository: ""
   pullPolicy: IfNotPresent
-  tag: 1.0.1-SNAPSHOT.aecc233
+  tag: 1.0.1-SNAPSHOT.d54ef47
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/observation-reporting-service/values-dts1.yaml
+++ b/charts/observation-reporting-service/values-dts1.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "dts1"
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/observation-reporting-service/values-dts1.yaml
+++ b/charts/observation-reporting-service/values-dts1.yaml
@@ -6,7 +6,7 @@ timezone: "America/Denver"
 image:
   repository: ""
   pullPolicy: IfNotPresent
-  tag: 1.0.1-SNAPSHOT.d54ef47
+  tag: 1.0.1-SNAPSHOT.aecc233
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/observation-reporting-service/values-feature.yaml
+++ b/charts/observation-reporting-service/values-feature.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "feature"
+timezone: ""
 
 image:
   repository: ""

--- a/charts/observation-reporting-service/values-feature.yaml
+++ b/charts/observation-reporting-service/values-feature.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "feature"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/observation-reporting-service/values-feature.yaml
+++ b/charts/observation-reporting-service/values-feature.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "feature"
-timezone: ""
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/observation-reporting-service/values-int1.yaml
+++ b/charts/observation-reporting-service/values-int1.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "int1"
-timezone: ""
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/observation-reporting-service/values-int1.yaml
+++ b/charts/observation-reporting-service/values-int1.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "int1"
+timezone: ""
 
 image:
   repository: ""

--- a/charts/observation-reporting-service/values-int1.yaml
+++ b/charts/observation-reporting-service/values-int1.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "int1"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/observation-reporting-service/values-test1.yaml
+++ b/charts/observation-reporting-service/values-test1.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "test"
+timezone: ""
 
 image:
   repository: ""

--- a/charts/observation-reporting-service/values-test1.yaml
+++ b/charts/observation-reporting-service/values-test1.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "test"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/observation-reporting-service/values-test1.yaml
+++ b/charts/observation-reporting-service/values-test1.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "test"
-timezone: ""
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/observation-reporting-service/values.yaml
+++ b/charts/observation-reporting-service/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "prod"
-timezone: ""
+timezone: "America/Denver"
 
 image:
   #repository: "public.ecr.aws/o1z7u2g7/cdc-nbs-modernization/data-reporting-service/observation-reporting-service"

--- a/charts/observation-reporting-service/values.yaml
+++ b/charts/observation-reporting-service/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "prod"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   #repository: "public.ecr.aws/o1z7u2g7/cdc-nbs-modernization/data-reporting-service/observation-reporting-service"

--- a/charts/observation-reporting-service/values.yaml
+++ b/charts/observation-reporting-service/values.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "prod"
+timezone: ""
 
 image:
   #repository: "public.ecr.aws/o1z7u2g7/cdc-nbs-modernization/data-reporting-service/observation-reporting-service"

--- a/charts/organization-reporting-service/templates/deployment.yaml
+++ b/charts/organization-reporting-service/templates/deployment.yaml
@@ -48,6 +48,8 @@ spec:
               value: {{ .Values.log.path }}
             - name: DB_ODSE_URL
               value: {{ .Values.odse.dburl }}
+            - name: TZ
+              value: {{ .Values.timezone }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/organization-reporting-service/values-dts1.yaml
+++ b/charts/organization-reporting-service/values-dts1.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "dts1"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/organization-reporting-service/values-dts1.yaml
+++ b/charts/organization-reporting-service/values-dts1.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "dts1"
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/organization-reporting-service/values-feature.yaml
+++ b/charts/organization-reporting-service/values-feature.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "feature"
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/organization-reporting-service/values-feature.yaml
+++ b/charts/organization-reporting-service/values-feature.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "feature"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/organization-reporting-service/values-int1.yaml
+++ b/charts/organization-reporting-service/values-int1.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "int1"
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/organization-reporting-service/values-int1.yaml
+++ b/charts/organization-reporting-service/values-int1.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "int1"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/organization-reporting-service/values-test1.yaml
+++ b/charts/organization-reporting-service/values-test1.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "test"
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/organization-reporting-service/values-test1.yaml
+++ b/charts/organization-reporting-service/values-test1.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "test"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/organization-reporting-service/values.yaml
+++ b/charts/organization-reporting-service/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "prod"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: "quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service/organization-reporting-service"

--- a/charts/organization-reporting-service/values.yaml
+++ b/charts/organization-reporting-service/values.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "prod"
+timezone: "America/Denver"
 
 image:
   repository: "quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service/organization-reporting-service"

--- a/charts/person-reporting-service/templates/deployment.yaml
+++ b/charts/person-reporting-service/templates/deployment.yaml
@@ -48,6 +48,8 @@ spec:
               value: {{ .Values.log.path }}
             - name: DB_ODSE_URL
               value: {{ .Values.odse.dburl }}
+            - name: TZ
+              value: {{ .Values.timezone }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/person-reporting-service/values-dts1.yaml
+++ b/charts/person-reporting-service/values-dts1.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "dts1"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/person-reporting-service/values-dts1.yaml
+++ b/charts/person-reporting-service/values-dts1.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "dts1"
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/person-reporting-service/values-feature.yaml
+++ b/charts/person-reporting-service/values-feature.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "feature"
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/person-reporting-service/values-feature.yaml
+++ b/charts/person-reporting-service/values-feature.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "feature"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/person-reporting-service/values-int1.yaml
+++ b/charts/person-reporting-service/values-int1.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "int1"
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/person-reporting-service/values-int1.yaml
+++ b/charts/person-reporting-service/values-int1.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "int1"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/person-reporting-service/values-test1.yaml
+++ b/charts/person-reporting-service/values-test1.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "test1"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/person-reporting-service/values-test1.yaml
+++ b/charts/person-reporting-service/values-test1.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "test1"
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/person-reporting-service/values.yaml
+++ b/charts/person-reporting-service/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "prod"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: "quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service/person-reporting-service"

--- a/charts/person-reporting-service/values.yaml
+++ b/charts/person-reporting-service/values.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "prod"
+timezone: "America/Denver"
 
 image:
   repository: "quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service/person-reporting-service"

--- a/charts/post-processing-reporting-service/templates/deployment.yaml
+++ b/charts/post-processing-reporting-service/templates/deployment.yaml
@@ -50,6 +50,8 @@ spec:
               value: {{ .Values.odse.dburl }}
             - name: DB_RDB_URL
               value: {{ .Values.rdb.dburl }}
+            - name: TZ
+              value: {{ .Values.timezone }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/post-processing-reporting-service/values-dts1.yaml
+++ b/charts/post-processing-reporting-service/values-dts1.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "dts1"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/post-processing-reporting-service/values-dts1.yaml
+++ b/charts/post-processing-reporting-service/values-dts1.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "dts1"
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/post-processing-reporting-service/values-feature.yaml
+++ b/charts/post-processing-reporting-service/values-feature.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "feature"
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/post-processing-reporting-service/values-feature.yaml
+++ b/charts/post-processing-reporting-service/values-feature.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "feature"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/post-processing-reporting-service/values-int1.yaml
+++ b/charts/post-processing-reporting-service/values-int1.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "int1"
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/post-processing-reporting-service/values-int1.yaml
+++ b/charts/post-processing-reporting-service/values-int1.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "int1"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/post-processing-reporting-service/values-test1.yaml
+++ b/charts/post-processing-reporting-service/values-test1.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "test"
+timezone: "America/Denver"
 
 image:
   repository: ""

--- a/charts/post-processing-reporting-service/values-test1.yaml
+++ b/charts/post-processing-reporting-service/values-test1.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "test"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: ""

--- a/charts/post-processing-reporting-service/values.yaml
+++ b/charts/post-processing-reporting-service/values.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 env: "prod"
+timezone: "America/Denver"
 
 image:
   repository: "quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service/post-processing-reporting-service"

--- a/charts/post-processing-reporting-service/values.yaml
+++ b/charts/post-processing-reporting-service/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 env: "prod"
-timezone: "America/Denver"
+timezone: "UTC"
 
 image:
   repository: "quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service/post-processing-reporting-service"


### PR DESCRIPTION
## Notes
- Updated the timezone for the services related to RTR, liquibase and debezium to Mountain Standard Time. Tested this with Observation service in DTS1 and everything looks as expected.

## JIRA
- https://cdc-nbs.atlassian.net/browse/CNDE-2077

## Testing
Before time zone change - 

```
2025-01-09T18:12:25.014Z  INFO 1 --- [common-util] [nio-8093-exec-1] g.c.e.i.c.InvestigationController        : Investigation Service Status OK
2025-01-09T18:12:25.015Z  INFO 1 --- [common-util] [nio-8093-exec-1] g.c.e.i.c.InvestigationController        : Default time zone is: UTC
```

After time zone change - 

```
2025-01-09T11:03:08.417-07:00  INFO 1 --- [common-util] [nio-8094-exec-1] g.c.e.o.c.ObservationController          : Observation Service Status OK
2025-01-09T11:03:08.419-07:00  INFO 1 --- [common-util] [nio-8094-exec-1] g.c.e.o.c.ObservationController          : Default time zone is: America/Denver
```

