### PR TITLE
[MU-34] adds timezone configurations to spring containers

### DIFF
--- a/charts/modernization-api/templates/deployment.yaml
+++ b/charts/modernization-api/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
-          command: ['java', '-jar', 'api.jar']
+          command: ['java', '-Duser.timezone={{ .Values.timezone }}', '-jar', 'api.jar']
           args: [            
             '--nbs.security.oidc.enabled={{ .Values.oidc.enabled }}',
             {{- if ((.Values).oidc).uri}}

--- a/charts/modernization-api/templates/deployment.yaml
+++ b/charts/modernization-api/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
-          command: ['java', '-Duser.timezone={{ .Values.timezone }}', '-jar', 'api.jar']
+          command: ['java', '-Duser.timezone={{ (.Values).timezone | default "UTC" }}', '-jar', 'api.jar']
           args: [            
             '--nbs.security.oidc.enabled={{ .Values.oidc.enabled }}',
             {{- if ((.Values).oidc).uri}}

--- a/charts/modernization-api/values.yaml
+++ b/charts/modernization-api/values.yaml
@@ -79,6 +79,9 @@ affinity: {}
 
 ingressHost: "app.EXAMPLE_DOMAIN"
 
+# The timezone to initialize the JVM with
+timezone: "UTC"
+
 elasticSearchHost: "http://elasticsearch.default.svc.cluster.local:9200"
 
 jdbc:

--- a/charts/nbs-gateway/templates/deployment.yaml
+++ b/charts/nbs-gateway/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           '--nbs.gateway.welcome.enabled={{ ((.Values).welcome).enabled | default "false" }}',
           '--nbs.gateway.landing.base={{  ((.Values).landing).base | default "/nbs/login" }}'
         ]
-        command: ['java', '-Duser.timezone={{ .Values.timezone }}', '-jar', 'api.jar']
+        command: ['java', '-Duser.timezone={{ (.Values).timezone | default "UTC" }}', '-jar', 'api.jar']
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         ports:
         - containerPort: 8000

--- a/charts/nbs-gateway/templates/deployment.yaml
+++ b/charts/nbs-gateway/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           '--nbs.gateway.welcome.enabled={{ ((.Values).welcome).enabled | default "false" }}',
           '--nbs.gateway.landing.base={{  ((.Values).landing).base | default "/nbs/login" }}'
         ]
-        command: ['java', '-jar', 'api.jar']
+        command: ['java', '-Duser.timezone={{ .Values.timezone }}', '-jar', 'api.jar']
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         ports:
         - containerPort: 8000

--- a/charts/nbs-gateway/values.yaml
+++ b/charts/nbs-gateway/values.yaml
@@ -50,6 +50,9 @@ nbsExternalName: app-classic.EXAMPLE_DOMAIN
 
 ingressHost: app.EXAMPLE_DOMAIN
 
+# The timezone to initialize the JVM with
+timezone: "UTC"
+
 modernizationApiHost: "modernization-api.default.svc.cluster.local:8080"
 
 modernizationUIHost: "modernization-api.default.svc.cluster.local:8080"

--- a/charts/page-builder-api/templates/deployment.yaml
+++ b/charts/page-builder-api/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
-          command: ['java', '-Duser.timezone={{ .Values.timezone }}', '-jar', 'api.jar']
+          command: ['java', '-Duser.timezone={{ (.Values).timezone | default "UTC" }}', '-jar', 'api.jar']
           args: [
             '--nbs.security.oidc.enabled={{ .Values.oidc.enabled }}',
             {{- if ((.Values).oidc).uri}}

--- a/charts/page-builder-api/templates/deployment.yaml
+++ b/charts/page-builder-api/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
-          command: ['java', '-jar', 'api.jar']
+          command: ['java', '-Duser.timezone={{ .Values.timezone }}', '-jar', 'api.jar']
           args: [
             '--nbs.security.oidc.enabled={{ .Values.oidc.enabled }}',
             {{- if ((.Values).oidc).uri}}

--- a/charts/page-builder-api/values.yaml
+++ b/charts/page-builder-api/values.yaml
@@ -13,6 +13,9 @@ ingressHost: "app.EXAMPLE_DOMAIN"
 # URL for access to classic application
 nbsExternalName: app-classic.EXAMPLE_DOMAIN
 
+# The timezone to initialize the JVM with
+timezone: "UTC"
+
 #Database access credentials
 jdbc:
   connectionString: "jdbc:sqlserver://EXAMPLE_DB_ENDPOINT:1433;databaseName=EXAMPLE_DB_NAME;user=EXAMPLE_DB_USER;password=EXAMPLE_DB_USER_PASSWORD;encrypt=true;trustServerCertificate=true;"


### PR DESCRIPTION
 Adds configuration for setting the timezone at deployment time for the JVM of the `modernization-api`, `page-builder-api` and `nbs-gateway` containers.  The default value is set in `values.yaml` for each service as `UTC`.

The `America/Denver` timezone would be used for containers that need to be set to the Mountain Time Zone.


[MU-34](https://cdc-nbs.atlassian.net/browse/MU-34)