### PR TITLE
[CNFT1-3778] Component size configuration and patient search filter feature

### DIFF
--- a/charts/modernization-api/templates/deployment.yaml
+++ b/charts/modernization-api/templates/deployment.yaml
@@ -64,6 +64,7 @@ spec:
             '--nbs.ui.features.patient.add.enabled={{ ((((.Values).ui).patient).add).enabled | default "false" }}',
             '--nbs.ui.features.patient.add.extended.enabled={{ (((((.Values).ui).patient).add).extended).enabled | default "false" }}',
             '--nbs.ui.features.patient.profile.enabled={{ ((((.Values).ui).patient).profile).enabled | default "false" }}',
+            '--nbs.ui.features.patient.search.filters.enabled={{ (((((.Values).ui).patient).search).filters).enabled | default "false" }}',
             '--nbs.ui.features.deduplication.enabled={{ (((.Values).ui).deduplication).enabled | default "false" }}',
             '--nbs.ui.settings.smarty.key={{ (((.Values).ui).smarty).key }}',
             '--nbs.ui.settings.analytics.host={{ (((.Values).ui).analytics).host }}',

--- a/charts/modernization-api/templates/deployment.yaml
+++ b/charts/modernization-api/templates/deployment.yaml
@@ -67,7 +67,8 @@ spec:
             '--nbs.ui.features.deduplication.enabled={{ (((.Values).ui).deduplication).enabled | default "false" }}',
             '--nbs.ui.settings.smarty.key={{ (((.Values).ui).smarty).key }}',
             '--nbs.ui.settings.analytics.host={{ (((.Values).ui).analytics).host }}',
-            '--nbs.ui.settings.analytics.key={{ (((.Values).ui).analytics).key }}'
+            '--nbs.ui.settings.analytics.key={{ (((.Values).ui).analytics).key }}',
+            '--nbs.ui.settings.defaults.sizing={{ (((.Values).ui).defaults).sizing | default "medium" }}'
             ]
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/modernization-api/values-int1.yaml
+++ b/charts/modernization-api/values-int1.yaml
@@ -128,4 +128,4 @@ ui:
       filters:
         enabled: true
   deduplication:
-    enabled: true
+    enabled: false

--- a/charts/modernization-api/values-int1.yaml
+++ b/charts/modernization-api/values-int1.yaml
@@ -104,6 +104,8 @@ ui:
     key: ""
   analytics:
     key: ""
+  defaults:
+    sizing: "small"
   search:
     events:
       enabled: true

--- a/charts/modernization-api/values-int1.yaml
+++ b/charts/modernization-api/values-int1.yaml
@@ -124,5 +124,8 @@ ui:
       enabled: true
       extended:
         enabled: true
+    search:
+      filters:
+        enabled: true
   deduplication:
     enabled: true

--- a/charts/modernization-api/values.yaml
+++ b/charts/modernization-api/values.yaml
@@ -146,6 +146,10 @@ ui:
       # Enables access to the modernized New patient - extended feature to create a patient with all available demographic data
       extended:
         enabled: true
+    search:
+      filters:
+        # Enables access to modernized Patient search filters
+        enabled: false
   deduplication:
     # Enable access to Deduplication screens
     enabled: false

--- a/charts/modernization-api/values.yaml
+++ b/charts/modernization-api/values.yaml
@@ -118,6 +118,9 @@ ui:
     host: "https://us.i.posthog.com"
     # The PostHog project key to associate frontend analytics with, when blank analytics will not be enabled
     key:
+  defaults:
+    # The default sizing of components
+    sizing: "medium"
   # feature flag configurations for modernized ui
   search:
     events:


### PR DESCRIPTION
Adds two new `modernization-api` configurations.

- `ui.defaults.sizing` to allow the configuration of the default sizing of components.  The default is `medium` with INT1 being set to `small`
- `ui.features.patient.search.filters.enabled` to enables access to modernized Patient search filters.  The default is `false` with the feature being enabled in INT1.

Verified defaults locally by executing
`helm template --debug ./modernization-api -f ./modernization-api/values.yaml `

Verified INT1 specific settings locally by executing
`helm template --debug ./modernization-api -f ./modernization-api/values-int1.yaml `