### PR TITLE
[Feature] Patient Search Filters off

### DIFF
--- a/charts/modernization-api/values-test2.yaml
+++ b/charts/modernization-api/values-test2.yaml
@@ -115,4 +115,4 @@ ui:
         enabled: true
     search:
       filters:
-        enabled: true
+        enabled: false


### PR DESCRIPTION
Turns off the Patient Search Filters in the TEST environment to match the list of features that will be released in `7.8.3`.  Patient Search Filters will be part of the next release.