### PR TITLE
[CNFT1-3854] adds session settings for modernization-ui

### DIFF
--- a/charts/modernization-api/templates/deployment.yaml
+++ b/charts/modernization-api/templates/deployment.yaml
@@ -69,7 +69,9 @@ spec:
             '--nbs.ui.settings.smarty.key={{ (((.Values).ui).smarty).key }}',
             '--nbs.ui.settings.analytics.host={{ (((.Values).ui).analytics).host }}',
             '--nbs.ui.settings.analytics.key={{ (((.Values).ui).analytics).key }}',
-            '--nbs.ui.settings.defaults.sizing={{ (((.Values).ui).defaults).sizing | default "medium" }}'
+            '--nbs.ui.settings.defaults.sizing={{ (((.Values).ui).defaults).sizing | default "medium" }}',
+            '--nbs.ui.settings.session.warning={{ (((.Values).ui).session).warning | default "28m" }}',
+            '--nbs.ui.settings.session.expiration={{ (((.Values).ui).session).expiration | default "30m" }}'
             ]
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/modernization-api/values.yaml
+++ b/charts/modernization-api/values.yaml
@@ -121,6 +121,14 @@ ui:
   defaults:
     # The default sizing of components
     sizing: "medium"
+  # The session configuration settings are meant for a user interface to be able to alert a user that a session is
+  # going to expire and do not actually control the session timeout. The warning, and expiration settings should
+  # correspond to the session expiration configuration on the OIDC provider.
+  session:
+    # A duration that defines the amount of time to wait while the user is idle before warning of session timeout.
+    warning: 28m
+    # A duration that defines the amount of time to wait while the user is idle before navigating the user to the expired session page.
+    expiration: 30m
   # feature flag configurations for modernized ui
   search:
     events:


### PR DESCRIPTION
Adds the `session.warning` and `session.expiration` variables to `values.yaml` of the `modernization-api` so that the idle timer in the `modernization-ui` can be configured to match the session settings of the IDP in the deployed environment.