### PR TITLE
Enable the RTR service flags for the 4.9.1 release

### DIFF
--- a/charts/investigation-reporting-service/values-int1.yaml
+++ b/charts/investigation-reporting-service/values-int1.yaml
@@ -76,7 +76,7 @@ featureFlag:
   phcDatamartEnable: "true"
   bmirdCaseEnable: "true"
   contactRecordEnable: "true"
-  treatmentEnable: "false"
+  treatmentEnable: "true"
 
 kafka:
   cluster: ""

--- a/charts/post-processing-reporting-service/values-test1.yaml
+++ b/charts/post-processing-reporting-service/values-test1.yaml
@@ -84,10 +84,10 @@ log:
 featureFlag:
   eventMetricEnable: "true"
   dTbHivEnable: "true"
-  morbReportDmEnable: "false"
-  invSummaryDmEnable: "false"
-  summaryReportEnable: "false"
-  aggregateReportEnable: "false"
+  morbReportDmEnable: "true"
+  invSummaryDmEnable: "true"
+  summaryReportEnable: "true"
+  aggregateReportEnable: "true"
 
 # Override available for readiness and liveness probes: port, initialDelaySeconds, periodSeconds, failureThreshold
 probes:


### PR DESCRIPTION
```  eventMetricEnable: "true"
     dTbHivEnable: "true"
     morbReportDmEnable: "true"
     invSummaryDmEnable: "true"
     summaryReportEnable: "true"
     aggregateReportEnable: "true"```