### PR TITLE
Added comments for the DI sftp param.

### DIFF
--- a/charts/dataingestion-service/values-dts1.yaml
+++ b/charts/dataingestion-service/values-dts1.yaml
@@ -116,7 +116,7 @@ sftp:
   elrFileExtns: "txt,hl7"
   phcrImporterVersion: "1"
   filePaths: "/"
-
+# filePaths value should be comma seperated like "/,/LAB-1,/lab-2, /lab-2/lab2-sub-folder"
 
 kafkaConcurrency: "1"
 

--- a/charts/dataingestion-service/values.yaml
+++ b/charts/dataingestion-service/values.yaml
@@ -118,7 +118,7 @@ sftp:
   elrFileExtns: "EXAMPLE_FILE_EXTNS"
   phcrImporterVersion: "EXAMPLE_VERSION"
   filePaths: "EXAMPLE_FILE_PATHS"
-
+# filePaths value should be comma seperated like "/,/LAB-1,/lab-2,/lab-2/lab2-sub-folder"
 ##################################
 
 apiPayloadMaxSize: "100MB"


### PR DESCRIPTION
## Description

Please include a summary of the changes and any key information a reviewer may need. Review the appropriate section below.


## Creating a new Helm chart?
1. Does the service require an ingress?
    - Kubernetes Ingress resource are PATH based and only handled by modernization-api and dataingestion-service helm charts. 
    - Currently, names of Kubernetes services have to be predictable if an ingress needs to point to them
2. Chart directory structure (specific environment values.yaml files are allowed at the same level as values.yaml)
    ```  
    |── charts
        ├── new-helm-chart
            ├── templates
            |   ├── tests
            |   ├── helpers.tpl
            |   ├── *.yaml
            |   └─ Chart.yaml
            ├── values.yaml
            └─  README.md
    ```    
3. **Do not include secret values anywhere in a Helm chart, take special care when creating values.yaml**
4. values.yaml is annotated to include parameter description and format as appropriate.
    - values.yaml is considered the production/default parameter file and should point to publically available container registries, if the service is publically available.    

## Updating a Helm Chart?
1. Ensure no secrets have been committed.
2. Ensure updates to existing Helm charts follow the guidelines contained in section [Creating a new Helm chart](#creating-a-new-helm-chart).

