### PR TITLE
Removes serviceAccount reference from deployment.yaml

### DIFF
--- a/charts/record-linker-api/templates/deployment.yaml
+++ b/charts/record-linker-api/templates/deployment.yaml
@@ -24,7 +24,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "record-linker-api.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:


### PR DESCRIPTION
## Description

Removes `serviceAccountName` reference from deployment.yaml for record-linker-api.