### PR TITLE
Deploy DI 7.9.3 release tag in int1 and test.

### DIFF
--- a/charts/dataingestion-service/values-int1.yaml
+++ b/charts/dataingestion-service/values-int1.yaml
@@ -5,7 +5,7 @@ env: "int1"
 image:
   repository: ""
   pullPolicy: IfNotPresent
-  tag: 1.0.1-SNAPSHOT.34fa7f9
+  tag: 1.0.1-SNAPSHOT.5723def
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/dataingestion-service/values-test2.yaml
+++ b/charts/dataingestion-service/values-test2.yaml
@@ -5,7 +5,7 @@ env: "test"
 image:
   repository: ""
   pullPolicy: IfNotPresent
-  tag: 1.0.1-SNAPSHOT.34fa7f9
+  tag: 1.0.1-SNAPSHOT.5723def
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## Description

To deploy Dataingestion 7.9.3 release tag in int1 and test.

## Creating a new Helm chart?
1. Does the service require an ingress?
    - Kubernetes Ingress resource are PATH based and only handled by modernization-api and dataingestion-service helm charts. 
    - Currently, names of Kubernetes services have to be predictable if an ingress needs to point to them
2. Chart directory structure (specific environment values.yaml files are allowed at the same level as values.yaml)
    ```  
    |── charts
        ├── new-helm-chart
            ├── templates
            |   ├── tests
            |   ├── helpers.tpl
            |   ├── *.yaml
            |   └─ Chart.yaml
            ├── values.yaml
            └─  README.md
    ```    
3. **Do not include secret values anywhere in a Helm chart, take special care when creating values.yaml**
4. values.yaml is annotated to include parameter description and format as appropriate.
    - values.yaml is considered the production/default parameter file and should point to publically available container registries, if the service is publically available.    

## Updating a Helm Chart?
1. Ensure no secrets have been committed.
2. Ensure updates to existing Helm charts follow the guidelines contained in section [Creating a new Helm chart](#creating-a-new-helm-chart).

