### PR TITLE
Flags for system management

### DIFF
--- a/charts/modernization-api/templates/deployment.yaml
+++ b/charts/modernization-api/templates/deployment.yaml
@@ -87,6 +87,7 @@ spec:
             '--nbs.ui.features.patient.search.filters.enabled={{ (((((.Values).ui).patient).search).filters).enabled | default "false" }}',
             '--nbs.ui.features.deduplication.enabled={{ (((.Values).ui).deduplication).enabled | default "false" }}',
             '--nbs.ui.features.deduplication.merge.enabled={{ ((((.Values).ui).deduplication).merge).enabled | default "false" }}',
+            '--nbs.ui.features.system.management.enabled={{ ((((.Values).ui).system).management).enabled | default "false" }}',
             '--nbs.ui.settings.smarty.key={{ (((.Values).ui).smarty).key }}',
             '--nbs.ui.settings.analytics.host={{ (((.Values).ui).analytics).host }}',
             '--nbs.ui.settings.analytics.key={{ (((.Values).ui).analytics).key }}',

--- a/charts/modernization-api/values-int1.yaml
+++ b/charts/modernization-api/values-int1.yaml
@@ -128,6 +128,9 @@ ui:
     enabled: true
     merge:
       enabled: true
+  system:
+    management:
+      enabled: true
 
 # Override available for readiness and liveness probes: port, initialDelaySeconds, periodSeconds, failureThreshold
 probes:

--- a/charts/modernization-api/values.yaml
+++ b/charts/modernization-api/values.yaml
@@ -159,6 +159,10 @@ ui:
     merge:
       # Enable acces to Deduplication merge screens
       enabled: false
+  system:
+    management:
+      # Enable access to System Management screen
+      enabled: false
 
 # Override available for readiness and liveness probes: port, initialDelaySeconds, periodSeconds, failureThreshold
 probes:


### PR DESCRIPTION
## Description

In order to add navigable links to the UI for a user to manage the deduplication configuration, the System Management page needs to be modernized. [CND-320](https://cdc-nbs.atlassian.net/browse/CND-320?atlOrigin=eyJpIjoiZjc2Zjc3ZTc1NDg1NDI1ZjljMDUwNThhOGZhOTIyYTkiLCJwIjoiaiJ9)

