### PR TITLE
CNDE-2845 : added table name in helmcharts for debezium for dts1

### DIFF
--- a/charts/debezium/values-dts1.yaml
+++ b/charts/debezium/values-dts1.yaml
@@ -75,7 +75,7 @@ connect:
       "table.include.list": "dbo.Person, dbo.Organization, dbo.Observation, dbo.Public_health_case, dbo.Treatment,
                              dbo.state_defined_field_data, dbo.Notification, dbo.Interview, dbo.CN_transportq_out,
                              dbo.Place, dbo.NBS_configuration, dbo.CT_contact, dbo.Auth_user, dbo.Intervention, 
-                             dbo.Act_relationship",
+                             dbo.Act_relationship, dbo.nrt_odse_lookup_question",
 
       "tasks.max": "1",
       "topic.prefix": "cdc",


### PR DESCRIPTION
## Description

Added the table entry for Covid Lab Postprocessing 


## Creating a new Helm chart?
1. Does the service require an ingress?
    - Kubernetes Ingress resource are PATH based and only handled by modernization-api and dataingestion-service helm charts. 
    - Currently, names of Kubernetes services have to be predictable if an ingress needs to point to them
2. Chart directory structure (specific environment values.yaml files are allowed at the same level as values.yaml)
    ```  
    |── charts
        ├── new-helm-chart
            ├── templates
            |   ├── tests
            |   ├── helpers.tpl
            |   ├── *.yaml
            |   └─ Chart.yaml
            ├── values.yaml
            └─  README.md
    ```    
3. **Do not include secret values anywhere in a Helm chart, take special care when creating values.yaml**
4. values.yaml is annotated to include parameter description and format as appropriate.
    - values.yaml is considered the production/default parameter file and should point to publically available container registries, if the service is publically available.    

## Updating a Helm Chart?
1. Ensure no secrets have been committed.
2. Ensure updates to existing Helm charts follow the guidelines contained in section [Creating a new Helm chart](#creating-a-new-helm-chart).

