### PR TITLE
CNDE-2866 add feature flags to control ES topics producing

### DIFF
--- a/charts/organization-reporting-service/templates/deployment.yaml
+++ b/charts/organization-reporting-service/templates/deployment.yaml
@@ -70,6 +70,8 @@ spec:
               value: {{ .Values.odse.dburl }}
             - name: TZ
               value: {{ .Values.timezone }}
+            - name: FF_ES_ENABLE
+              value: {{ .Values.featureFlag.elasticSearchEnable }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/organization-reporting-service/values-dts1.yaml
+++ b/charts/organization-reporting-service/values-dts1.yaml
@@ -53,6 +53,9 @@ jdbc:
 odse:
   dburl: ""
 
+featureFlag:
+  elasticSearchEnable: "false"
+
 kafka:
   cluster: ""
 

--- a/charts/organization-reporting-service/values-feature.yaml
+++ b/charts/organization-reporting-service/values-feature.yaml
@@ -61,6 +61,9 @@ jdbc:
 odse:
   dburl: ""
 
+featureFlag:
+  elasticSearchEnable: "false"
+
 kafka:
   cluster: ""
 

--- a/charts/organization-reporting-service/values-int1.yaml
+++ b/charts/organization-reporting-service/values-int1.yaml
@@ -59,6 +59,9 @@ jdbc:
 odse:
   dburl: ""
 
+featureFlag:
+  elasticSearchEnable: "false"
+
 kafka:
   cluster: ""
 

--- a/charts/organization-reporting-service/values-test1.yaml
+++ b/charts/organization-reporting-service/values-test1.yaml
@@ -59,6 +59,9 @@ jdbc:
 odse:
   dburl: ""
 
+featureFlag:
+  elasticSearchEnable: "false"
+
 kafka:
   cluster: ""
 

--- a/charts/organization-reporting-service/values.yaml
+++ b/charts/organization-reporting-service/values.yaml
@@ -52,6 +52,9 @@ jdbc:
 odse:
   dburl: "EXAMPLE_FIXME_DB_URL"
 
+featureFlag:
+  elasticSearchEnable: "false"
+
 kafka:
   cluster: "<<EXAMPLE_MSK_KAFKA_ENDPOINT>>"
 

--- a/charts/person-reporting-service/templates/deployment.yaml
+++ b/charts/person-reporting-service/templates/deployment.yaml
@@ -71,6 +71,8 @@ spec:
               value: {{ .Values.odse.dburl }}
             - name: TZ
               value: {{ .Values.timezone }}
+            - name: FF_ES_ENABLE
+              value: {{ .Values.featureFlag.elasticSearchEnable }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/person-reporting-service/values-dts1.yaml
+++ b/charts/person-reporting-service/values-dts1.yaml
@@ -53,6 +53,9 @@ jdbc:
 odse:
   dburl: ""
 
+featureFlag:
+  elasticSearchEnable: "false"
+
 kafka:
   cluster: ""
 

--- a/charts/person-reporting-service/values-feature.yaml
+++ b/charts/person-reporting-service/values-feature.yaml
@@ -61,6 +61,9 @@ jdbc:
 odse:
   dburl: ""
 
+featureFlag:
+  elasticSearchEnable: "false"
+
 kafka:
   cluster: ""
 

--- a/charts/person-reporting-service/values-int1.yaml
+++ b/charts/person-reporting-service/values-int1.yaml
@@ -61,6 +61,9 @@ jdbc:
 odse:
   dburl: ""
 
+featureFlag:
+  elasticSearchEnable: "false"
+
 kafka:
   cluster: ""
 

--- a/charts/person-reporting-service/values-test1.yaml
+++ b/charts/person-reporting-service/values-test1.yaml
@@ -59,6 +59,9 @@ jdbc:
 odse:
   dburl: ""
 
+featureFlag:
+  elasticSearchEnable: "false"
+
 kafka:
   cluster: ""
 

--- a/charts/person-reporting-service/values.yaml
+++ b/charts/person-reporting-service/values.yaml
@@ -52,6 +52,9 @@ jdbc:
 odse:
   dburl: "<<EXAMPLE_FIXME_ODSE_DB_URL>>"
 
+featureFlag:
+  elasticSearchEnable: "false"
+
 kafka:
   cluster: "<<EXAMPLE_MSK_KAFKA_ENDPOINT>>"
 


### PR DESCRIPTION
## Description

Add feature flags to organization and person service to control producing ElasticSearch-related topics in RTR pipeline. Disabling by default (feature is not used now) to mitigate performance impact by preventing unnecessary load on the services and increased Kafka storage usage.

## JIRA

- **Related story**: [CNDE-2866](https://cdc-nbs.atlassian.net/browse/CNDE-2866)

