### PR TITLE
added consolidated rtr helm chart

### DIFF
--- a/charts/rtr/Chart.yaml
+++ b/charts/rtr/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: rtr
+description: A Consolidated Helm chart for deploying Reporting services
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.1.8
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "7.10.0"

--- a/charts/rtr/templates/_helpers.tpl
+++ b/charts/rtr/templates/_helpers.tpl
@@ -1,0 +1,24 @@
+{{/*
+Generate fullname for the given serviceName key
+*/}}
+{{- define "fullname" -}}
+{{- $serviceName := .serviceName | replace "." "-" -}}
+{{- printf "%s-%s" .Release.Name $serviceName | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+Generate serviceAccountName for the given serviceName
+*/}}
+{{- define "serviceAccountName" -}}
+{{- include "fullname" . -}}
+{{- end }}
+
+{{/*
+Common labels for all resources, using serviceName from dict
+*/}}
+{{- define "commonLabels" -}}
+app.kubernetes.io/name: {{ .serviceName }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/charts/rtr/templates/deployment.yaml
+++ b/charts/rtr/templates/deployment.yaml
@@ -1,0 +1,112 @@
+{{- range $serviceName, $service := .Values.services }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ printf "%s-%s" $.Release.Name $serviceName | trunc 63 | trimSuffix "-" }}"
+  labels:
+    app.kubernetes.io/name: "{{ $serviceName }}"
+    app.kubernetes.io/instance: "{{ $.Release.Name }}"
+    app.kubernetes.io/version: "{{ $service.tag | default "latest" }}"
+    app.kubernetes.io/managed-by: "{{ $.Release.Service }}"
+spec:
+  replicas: {{ $service.replicaCount | default $.Values.replicaCount | default 1 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: "{{ $serviceName }}"
+      app.kubernetes.io/instance: "{{ $.Release.Name }}"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "{{ $serviceName }}"
+        app.kubernetes.io/instance: "{{ $.Release.Name }}"
+      {{- with $service.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{- if $service.serviceAccount.name }} {{ $service.serviceAccount.name | quote }} {{- else }} {{ printf "%s-%s" $.Release.Name $serviceName | trunc 63 | trimSuffix "-" | quote }} {{- end }}
+      containers:
+        - name: {{ $serviceName }}
+          image: "{{ $.Values.image.repository }}/{{ $serviceName }}-service:{{ $.Values.image.tag }}"
+          imagePullPolicy: {{- if and (hasKey $service "image") (hasKey $service.image "pullPolicy") }} {{ $service.image.pullPolicy }}{{- else }} {{ $.Values.image.pullPolicy | default "IfNotPresent" }}{{- end }}
+          ports:
+            - containerPort: {{ $service.service.port | default 8080 }}
+
+          {{- if and (hasKey $service "probes") (hasKey $service.probes "readiness") (get $service.probes.readiness "enabled") }}
+          readinessProbe:
+            httpGet:
+              path: {{ $service.probes.readiness.path | default (printf "/reporting/%s-svc/status" $serviceName) | quote }}
+              port: {{ $service.service.port | default 8080 }}
+            initialDelaySeconds: {{ $service.probes.readiness.initialDelaySeconds | default 30 }}
+            periodSeconds: {{ $service.probes.readiness.periodSeconds | default 10 }}
+            failureThreshold: {{ $service.probes.readiness.failureThreshold | default 5 }}
+          {{- end }}
+
+          {{- if and (hasKey $service "probes") (hasKey $service.probes "liveness") (get $service.probes.liveness "enabled") }}
+          livenessProbe:
+            httpGet:
+              path: {{ $service.probes.liveness.path | default (printf "/reporting/%s-svc/status" $serviceName) | quote }}
+              port: {{ $service.service.port | default 8080 }}
+            initialDelaySeconds: {{ $service.probes.liveness.initialDelaySeconds | default 60 }}
+            periodSeconds: {{ $service.probes.liveness.periodSeconds | default 30 }}
+            failureThreshold: {{ $service.probes.liveness.failureThreshold | default 5 }}
+          {{- end }}
+
+          resources:
+            {{- if $service.resources }}
+            {{- toYaml $service.resources | nindent 12 }}
+            {{- else }}
+            {{- toYaml $.Values.resources | nindent 12 }}
+            {{- end }}
+
+          env:
+            - name: ENV
+              value: {{ $service.env | default $.Values.env | quote }}
+            - name: TZ
+              value: {{ $service.timezone | default $.Values.timezone | quote }}
+            - name: DB_USERNAME
+              value: {{- if and (hasKey $service "jdbc") (hasKey $service.jdbc "username") }} {{ $service.jdbc.username | quote }} {{- else }} {{ $.Values.jdbc.username | quote }} {{- end }}
+            - name: DB_PASSWORD
+              value: {{- if and (hasKey $service "jdbc") (hasKey $service.jdbc "password") }} {{ $service.jdbc.password | quote }} {{- else }} {{ $.Values.jdbc.password | quote }} {{- end }}
+            - name: DB_ODSE_URL
+              value: {{- if and (hasKey $service "odse") (hasKey $service.odse "dburl") }} {{ $service.odse.dburl | quote }} {{- else }} {{ $.Values.odse.dburl | quote }} {{- end }}
+            - name: DB_RDB_URL
+              value: {{- if and (hasKey $service "rdb") (hasKey $service.rdb "dburl") }} {{ $service.rdb.dburl | quote }} {{- else }} "" {{- end }}
+            - name: KAFKA_BOOTSTRAP_SERVER
+              value: {{- if and (hasKey $service "kafka") (hasKey $service.kafka "cluster") }} {{ $service.kafka.cluster | quote }} {{- else }} {{ $.Values.kafka.cluster | quote }} {{- end }}
+            - name: DA_LOG_PATH
+              value: {{- if and (hasKey $service "log") (hasKey $service.log "path") }} {{ $service.log.path | quote }} {{- else }} {{ $.Values.log.path | quote }} {{- end }}
+            - name: FF_COVID_DM_ENABLE
+              value: {{- if and (hasKey $service "featureFlag") (hasKey $service.featureFlag "covidDmEnable") }} {{ $service.featureFlag.covidDmEnable | quote }} {{- else }} "false" {{- end }}
+
+      {{- if $service.nodeSelector }}
+      nodeSelector:
+        {{- toYaml $service.nodeSelector | nindent 8 }}
+      {{- else if $.Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml $.Values.nodeSelector | nindent 8 }}
+      {{- end }}
+
+      {{- if $service.affinity }}
+      affinity:
+        {{- toYaml $service.affinity | nindent 8 }}
+      {{- else if $.Values.affinity }}
+      affinity:
+        {{- toYaml $.Values.affinity | nindent 8 }}
+      {{- end }}
+
+      {{- if $service.tolerations }}
+      tolerations:
+        {{- toYaml $service.tolerations | nindent 8 }}
+      {{- else if $.Values.tolerations }}
+      tolerations:
+        {{- toYaml $.Values.tolerations | nindent 8 }}
+      {{- end }}
+
+      {{- with $.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+{{- end }}

--- a/charts/rtr/templates/deployment.yaml
+++ b/charts/rtr/templates/deployment.yaml
@@ -77,8 +77,6 @@ spec:
               value: {{- if and (hasKey $service "kafka") (hasKey $service.kafka "cluster") }} {{ $service.kafka.cluster | quote }} {{- else }} {{ $.Values.kafka.cluster | quote }} {{- end }}
             - name: DA_LOG_PATH
               value: {{- if and (hasKey $service "log") (hasKey $service.log "path") }} {{ $service.log.path | quote }} {{- else }} {{ $.Values.log.path | quote }} {{- end }}
-            - name: FF_COVID_DM_ENABLE
-              value: {{- if and (hasKey $service "featureFlag") (hasKey $service.featureFlag "covidDmEnable") }} {{ $service.featureFlag.covidDmEnable | quote }} {{- else }} "false" {{- end }}
             - name: FF_PHC_DM_ENABLE
               value: {{- if and (hasKey $service "featureFlag") (hasKey $service.featureFlag "phcDatamartEnable") }} {{ $service.featureFlag.phcDatamartEnable | quote }} {{- else }} "false" {{- end }}
             - name: FF_ES_ENABLE

--- a/charts/rtr/templates/deployment.yaml
+++ b/charts/rtr/templates/deployment.yaml
@@ -77,6 +77,8 @@ spec:
               value: {{- if and (hasKey $service "kafka") (hasKey $service.kafka "cluster") }} {{ $service.kafka.cluster | quote }} {{- else }} {{ $.Values.kafka.cluster | quote }} {{- end }}
             - name: DA_LOG_PATH
               value: {{- if and (hasKey $service "log") (hasKey $service.log "path") }} {{ $service.log.path | quote }} {{- else }} {{ $.Values.log.path | quote }} {{- end }}
+            - name: FF_COVID_DM_ENABLE
+              value: {{- if and (hasKey $service "featureFlag") (hasKey $service.featureFlag "covidDmEnable") }} {{ $service.featureFlag.covidDmEnable | quote }} {{- else }} "false" {{- end }}
             - name: FF_PHC_DM_ENABLE
               value: {{- if and (hasKey $service "featureFlag") (hasKey $service.featureFlag "phcDatamartEnable") }} {{ $service.featureFlag.phcDatamartEnable | quote }} {{- else }} "false" {{- end }}
             - name: FF_ES_ENABLE

--- a/charts/rtr/templates/deployment.yaml
+++ b/charts/rtr/templates/deployment.yaml
@@ -79,6 +79,10 @@ spec:
               value: {{- if and (hasKey $service "log") (hasKey $service.log "path") }} {{ $service.log.path | quote }} {{- else }} {{ $.Values.log.path | quote }} {{- end }}
             - name: FF_COVID_DM_ENABLE
               value: {{- if and (hasKey $service "featureFlag") (hasKey $service.featureFlag "covidDmEnable") }} {{ $service.featureFlag.covidDmEnable | quote }} {{- else }} "false" {{- end }}
+            - name: FF_PHC_DM_ENABLE
+              value: {{- if and (hasKey $service "featureFlag") (hasKey $service.featureFlag "phcDatamartEnable") }} {{ $service.featureFlag.phcDatamartEnable | quote }} {{- else }} "false" {{- end }}
+            - name: FF_ES_ENABLE
+              value: {{- if and (hasKey $service "featureFlag") (hasKey $service.featureFlag "elasticSearchEnable") }} {{ $service.featureFlag.elasticSearchEnable | quote }} {{- else }} "false" {{- end }}
 
       {{- if $service.nodeSelector }}
       nodeSelector:

--- a/charts/rtr/templates/deployment.yaml
+++ b/charts/rtr/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: "{{ $serviceName }}"
     app.kubernetes.io/instance: "{{ $.Release.Name }}"
-    app.kubernetes.io/version: "{{ $service.tag | default "latest" }}"
+    app.kubernetes.io/version: "{{ $service.image.tag | default "latest" }}"
     app.kubernetes.io/managed-by: "{{ $.Release.Service }}"
 spec:
   replicas: {{ $service.replicaCount | default $.Values.replicaCount | default 1 }}
@@ -28,8 +28,8 @@ spec:
       serviceAccountName: {{- if $service.serviceAccount.name }} {{ $service.serviceAccount.name | quote }} {{- else }} {{ printf "%s-%s" $.Release.Name $serviceName | trunc 63 | trimSuffix "-" | quote }} {{- end }}
       containers:
         - name: {{ $serviceName }}
-          image: "{{ $.Values.image.repository }}/{{ $serviceName }}-service:{{ $.Values.image.tag }}"
-          imagePullPolicy: {{- if and (hasKey $service "image") (hasKey $service.image "pullPolicy") }} {{ $service.image.pullPolicy }}{{- else }} {{ $.Values.image.pullPolicy | default "IfNotPresent" }}{{- end }}
+          image: "{{ $service.image.repository }}/{{ $service.image.name }}:{{ $service.image.tag }}"
+          imagePullPolicy: "{{ $service.image.pullPolicy | default "IfNotPresent" }}"
           ports:
             - containerPort: {{ $service.service.port | default 8080 }}
 

--- a/charts/rtr/templates/hpa.yaml
+++ b/charts/rtr/templates/hpa.yaml
@@ -1,0 +1,37 @@
+{{- range $serviceName, $service := .Values.services }}
+  {{- if and (hasKey $service "autoscaling") $service.autoscaling.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ printf "%s-%s" $.Release.Name $serviceName | trunc 63 | trimSuffix "-" }}
+  labels:
+    app.kubernetes.io/name: {{ $serviceName }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ printf "%s-%s" $.Release.Name $serviceName | trunc 63 | trimSuffix "-" }}
+  minReplicas: {{ $service.autoscaling.minReplicas | default 1 }}
+  maxReplicas: {{ $service.autoscaling.maxReplicas | default 100 }}
+  metrics:
+    {{- if $service.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $service.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if $service.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ $service.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/rtr/templates/service.yaml
+++ b/charts/rtr/templates/service.yaml
@@ -1,0 +1,23 @@
+{{- range $serviceName, $service := .Values.services }}
+  {{- if $service.service }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-service" $serviceName | trunc 63 | trimSuffix "-" }}
+  labels:
+    app.kubernetes.io/name: {{ $serviceName }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+spec:
+  type: {{ $service.service.type | default "ClusterIP" }}
+  ports:
+    - port: {{ $service.service.port | default 8080 }}
+      targetPort: {{ $service.service.port | default 8080 }}
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ $serviceName }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+{{- end }}
+{{- end }}

--- a/charts/rtr/templates/serviceaccount.yaml
+++ b/charts/rtr/templates/serviceaccount.yaml
@@ -1,0 +1,17 @@
+{{- range $serviceName, $service := .Values.services }}
+  {{- if and (hasKey $service "serviceAccount") $service.serviceAccount.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ printf "%s-%s" $.Release.Name $serviceName | trunc 63 | trimSuffix "-" }}
+  labels:
+    app.kubernetes.io/name: {{ $serviceName }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+  {{- with $service.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/rtr/values.yaml
+++ b/charts/rtr/values.yaml
@@ -2,12 +2,12 @@ replicaCount: 1
 env: prod
 timezone: UTC
 jdbc:
-  username: ''
-  password: ''
+  username: 'nbs_ods'
+  password: 'ods'
 odse:
-  dburl: ''
+  dburl: 'jdbc:sqlserver://nbs-db.private-dts1.nbspreview.com:1433;databaseName=rdb_modern;encrypt=true;trustServerCertificate=true'
 kafka:
-  cluster: ''
+  cluster: 'b-1.nrtreportingdebezium.89ln12.c11.kafka.us-east-1.amazonaws.com:9092,b-2.nrtreportingdebezium.89ln12.c11.kafka.us-east-1.amazonaws.com:9092'
 serviceAccount:
   create: true
   annotations: {}
@@ -18,11 +18,11 @@ podAnnotations:
   prometheus.io/port: '8081'
 resources:
   limits:
+    memory: 1Gi
+    cpu: 500m
+  requests:
     memory: 512Mi
     cpu: 250m
-  requests:
-    memory: 256Mi
-    cpu: 125m
 autoscaling:
   enabled: false
   minReplicas: 1
@@ -47,9 +47,6 @@ services:
       annotations: {}
     featureFlag:
       phcDatamartEnable: 'true'
-      bmirdCaseEnable: 'true'
-      contactRecordEnable: 'true'
-      treatmentEnable: 'false'
     log:
       path: /usr/share/investigation-reporting/data
     probes:
@@ -197,7 +194,6 @@ services:
     log:
       path: /usr/share/post-processing-reporting/data
     featureFlag:
-      covidDmEnable: 'false'
     probes:
       readiness:
         enabled: true

--- a/charts/rtr/values.yaml
+++ b/charts/rtr/values.yaml
@@ -7,14 +7,14 @@ env: prod              # Environment indicator
 timezone: UTC          # Container timezone
 
 jdbc:
-  username: ''         # DB username (should be set in secrets)
-  password: ''         # DB password (should be set in secrets)
+  username: "nbs_ods"
+  password: "ods"
 
 odse:
-  dburl: ''            # ODSE DB URL
+  dburl: "jdbc:sqlserver://cdc-nbs-fts3-rds-mssql.czklgy8jnptr.us-east-1.rds.amazonaws.com:1433;databaseName=NBS_ODSE;encrypt=true;trustServerCertificate=true;"
 
 kafka:
-  cluster: ''          # Kafka cluster bootstrap servers
+  cluster: "b-2.cdcnbsfts3development.fm0nf5.c12.kafka.us-east-1.amazonaws.com:9094,b-1.cdcnbsfts3development.fm0nf5.c12.kafka.us-east-1.amazonaws.com:9094"
 
 serviceAccount:
   create: true
@@ -46,9 +46,9 @@ affinity: {}
 
 probes:
   readiness:
-    enabled: true      # Enable readiness probe
+    enabled: true
   liveness:
-    enabled: true      # Enable liveness probe
+    enabled: true
 
 # ================================================
 # Service-specific configurations
@@ -66,7 +66,8 @@ services:
       name: ''
       annotations: {}
     featureFlag:
-      phcDatamartEnable: 'true'
+      phcDatamartEnable: "true"
+      covidDmEnable: "false"
     log:
       path: /usr/share/investigation-reporting/data
     probes:
@@ -83,9 +84,9 @@ services:
         periodSeconds: 30
         failureThreshold: 5
     image:
-      repository: ''
-      name: ''
-      tag: ''
+      repository: "quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service"
+      name: "investigation-reporting-service"
+      tag: "v1.1.9"
       pullPolicy: IfNotPresent
 
   # ----------------------------------------
@@ -114,9 +115,9 @@ services:
         periodSeconds: 30
         failureThreshold: 5
     image:
-      repository: ''
-      name: ''
-      tag: ''
+      repository: "quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service"
+      name: "ldfdata-reporting-service"
+      tag: "v1.1.9"
       pullPolicy: IfNotPresent
 
   # ----------------------------------------
@@ -145,9 +146,9 @@ services:
         periodSeconds: 30
         failureThreshold: 5
     image:
-      repository: ''
-      name: ''
-      tag: ''
+      repository: "quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service"
+      name: "observation-reporting-service"
+      tag: "v1.1.9"
       pullPolicy: IfNotPresent
 
   # ----------------------------------------
@@ -176,9 +177,9 @@ services:
         periodSeconds: 30
         failureThreshold: 5
     image:
-      repository: ''
-      name: ''
-      tag: ''
+      repository: "quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service"
+      name: "organization-reporting-service"
+      tag: "v1.1.9"
       pullPolicy: IfNotPresent
 
   # ----------------------------------------
@@ -192,8 +193,8 @@ services:
       name: ''
       annotations: {}
     featureFlag:
-      elasticSearchEnable: 'true'
-      covidDmEnable: 'false'
+      elasticSearchEnable: "true"
+      covidDmEnable: "false"
     log:
       path: /usr/share/person-reporting/data
     probes:
@@ -210,9 +211,9 @@ services:
         periodSeconds: 30
         failureThreshold: 5
     image:
-      repository: ''
-      name: ''
-      tag: ''
+      repository: "quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service"
+      name: "person-reporting-service"
+      tag: "v1.1.9"
       pullPolicy: IfNotPresent
 
   # ----------------------------------------
@@ -228,7 +229,7 @@ services:
       name: ''
       annotations: {}
     rdb:
-      dburl: ''
+      dburl: "jdbc:sqlserver://cdc-nbs-fts3-rds-mssql.czklgy8jnptr.us-east-1.rds.amazonaws.com:1433;databaseName=rdb_modern;encrypt=true;trustServerCertificate=true;"
     log:
       path: /usr/share/post-processing-reporting/data
     probes:
@@ -245,9 +246,9 @@ services:
         periodSeconds: 30
         failureThreshold: 5
     image:
-      repository: ''
-      name: ''
-      tag: ''
+      repository: "quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service"
+      name: "post-processing-reporting-service"
+      tag: "v1.1.9"
       pullPolicy: IfNotPresent
     featureFlag:
-      covidDmEnable: 'false'
+      covidDmEnable: "false"

--- a/charts/rtr/values.yaml
+++ b/charts/rtr/values.yaml
@@ -179,6 +179,9 @@ services:
       name: person-reporting-service
       tag: v1.1.8
       pullPolicy: IfNotPresent
+    featureFlag:
+      elasticSearchEnable: 'true'
+      covidDmEnable: 'false'
   post-processing-reporting:
     service:
       port: 8095
@@ -193,7 +196,10 @@ services:
       dburl: ''
     log:
       path: /usr/share/post-processing-reporting/data
+<<<<<<< HEAD
     featureFlag:
+=======
+>>>>>>> dc749740 (updated deployment yaml with feature flag)
     probes:
       readiness:
         enabled: true
@@ -212,3 +218,5 @@ services:
       name: post-processing-reporting-service
       tag: v1.1.8
       pullPolicy: IfNotPresent
+    featureFlag:
+      covidDmEnable: 'false'

--- a/charts/rtr/values.yaml
+++ b/charts/rtr/values.yaml
@@ -1,233 +1,218 @@
-# -----------------------------
-# Global/shared configuration
-# -----------------------------
 replicaCount: 1
-env: "prod"
-timezone: "UTC"
-
-image:
-  repository: "quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service"
-  tag: "v1.1.8"
-  pullPolicy: IfNotPresent
-
-imagePullSecrets: []
-
+env: prod
+timezone: UTC
 jdbc:
-  username: ""
-  password: ""
-
+  username: ''
+  password: ''
 odse:
-  dburl: ""
-
-
+  dburl: ''
 kafka:
-  cluster: ""
-
+  cluster: ''
 serviceAccount:
   create: true
   annotations: {}
-  name: ""
-
+  name: ''
 podAnnotations:
-  prometheus.io/scrape: "true"
-  prometheus.io/path: "/actuator/prometheus"
-  prometheus.io/port: "8081"
-
-resources: 
+  prometheus.io/scrape: 'true'
+  prometheus.io/path: /actuator/prometheus
+  prometheus.io/port: '8081'
+resources:
   limits:
-    memory: "512Mi"  
-    cpu: "250m"      
+    memory: 512Mi
+    cpu: 250m
   requests:
-    memory: "256Mi"  
-    cpu: "125m"
-    
+    memory: 256Mi
+    cpu: 125m
 autoscaling:
   enabled: false
   minReplicas: 1
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
-
 nodeSelector: {}
 tolerations: []
 affinity: {}
-
 probes:
   readiness:
     enabled: true
   liveness:
     enabled: true
-
-# -----------------------------
-# Per-service configuration
-# -----------------------------
 services:
-
   investigation-reporting:
     service:
       port: 8093
       httpsPort: 443
-
     serviceAccount:
       create: true
-      name: ""          # Optional, leave empty to auto-generate
+      name: ''
       annotations: {}
-
     featureFlag:
-      phcDatamartEnable: "true"
-      bmirdCaseEnable: "true"
-      contactRecordEnable: "true"
-      treatmentEnable: "false"
-
+      phcDatamartEnable: 'true'
+      bmirdCaseEnable: 'true'
+      contactRecordEnable: 'true'
+      treatmentEnable: 'false'
     log:
-      path: "/usr/share/investigation-reporting/data"
-
+      path: /usr/share/investigation-reporting/data
     probes:
       readiness:
         enabled: true
-        path: "/reporting/investigation-svc/status"
+        path: /reporting/investigation-svc/status
         initialDelaySeconds: 30
         periodSeconds: 10
         failureThreshold: 5
       liveness:
         enabled: true
-        path: "/reporting/investigation-svc/status"
+        path: /reporting/investigation-svc/status
         initialDelaySeconds: 60
         periodSeconds: 30
         failureThreshold: 5
-
+    image:
+      repository: quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service
+      name: investigation-reporting-service
+      tag: v1.1.8
+      pullPolicy: IfNotPresent
   ldfdata-reporting:
     service:
       port: 8097
       httpsPort: 443
-
     serviceAccount:
       create: true
-      name: ""          # Optional, leave empty to auto-generate
+      name: ''
       annotations: {}
-
     log:
-      path: "/usr/share/ldfdata-reporting/data"
+      path: /usr/share/ldfdata-reporting/data
     probes:
       readiness:
         enabled: true
-        path: "/reporting/ldfdata-svc/status"
+        path: /reporting/ldfdata-svc/status
         initialDelaySeconds: 30
         periodSeconds: 10
         failureThreshold: 5
       liveness:
         enabled: true
-        path: "/reporting/ldfdata-svc/status"
+        path: /reporting/ldfdata-svc/status
         initialDelaySeconds: 60
         periodSeconds: 30
         failureThreshold: 5
-
+    image:
+      repository: quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service
+      name: ldfdata-reporting-service
+      tag: v1.1.8
+      pullPolicy: IfNotPresent
   observation-reporting:
     service:
       port: 8094
       httpsPort: 443
-
     serviceAccount:
       create: true
-      name: ""          # Optional, leave empty to auto-generate
+      name: ''
       annotations: {}
-
     log:
-      path: "/usr/share/observation-reporting/data"
-
+      path: /usr/share/observation-reporting/data
     probes:
       readiness:
         enabled: true
-        path: "/reporting/observation-svc/status"
+        path: /reporting/observation-svc/status
         initialDelaySeconds: 30
         periodSeconds: 10
         failureThreshold: 5
       liveness:
         enabled: true
-        path: "/reporting/observation-svc/status"
+        path: /reporting/observation-svc/status
         initialDelaySeconds: 60
         periodSeconds: 30
         failureThreshold: 5
-
+    image:
+      repository: quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service
+      name: observation-reporting-service
+      tag: v1.1.8
+      pullPolicy: IfNotPresent
   organization-reporting:
     service:
       port: 8092
       httpsPort: 443
-
     serviceAccount:
       create: true
-      name: ""          # Optional, leave empty to auto-generate
+      name: ''
       annotations: {}
-
     log:
-      path: "/usr/share/organization-reporting/data"
-
+      path: /usr/share/organization-reporting/data
     probes:
       readiness:
         enabled: true
-        path: "/reporting/organization-svc/status"
+        path: /reporting/organization-svc/status
         initialDelaySeconds: 30
         periodSeconds: 10
         failureThreshold: 5
       liveness:
         enabled: true
-        path: "/reporting/organization-svc/status"
+        path: /reporting/organization-svc/status
         initialDelaySeconds: 60
         periodSeconds: 30
         failureThreshold: 5
-
+    image:
+      repository: quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service
+      name: organization-reporting-service
+      tag: v1.1.8
+      pullPolicy: IfNotPresent
   person-reporting:
     service:
       port: 8091
       httpsPort: 443
-
     serviceAccount:
       create: true
-      name: ""          # Optional, leave empty to auto-generate
+      name: ''
       annotations: {}
-
     log:
-      path: "/usr/share/person-reporting/data"
+      path: /usr/share/person-reporting/data
     probes:
       readiness:
         enabled: true
-        path: "/reporting/person-svc/status"
+        path: /reporting/person-svc/status
         initialDelaySeconds: 30
         periodSeconds: 10
         failureThreshold: 5
       liveness:
         enabled: true
-        path: "/reporting/person-svc/status"
+        path: /reporting/person-svc/status
         initialDelaySeconds: 60
         periodSeconds: 30
         failureThreshold: 5
-
+    image:
+      repository: quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service
+      name: person-reporting-service
+      tag: v1.1.8
+      pullPolicy: IfNotPresent
   post-processing-reporting:
     service:
       port: 8095
       httpsPort: 443
       fixedDelay:
         cachedIds: 2
-
     serviceAccount:
       create: true
-      name: ""          # Optional, leave empty to auto-generate
+      name: ''
       annotations: {}
     rdb:
-        dburl: ""
+      dburl: ''
     log:
-        path: "/usr/share/post-processing-reporting/data"
+      path: /usr/share/post-processing-reporting/data
     featureFlag:
-      covidDmEnable: "false"
+      covidDmEnable: 'false'
     probes:
       readiness:
         enabled: true
-        path: "/reporting/post-processing-svc/status"
+        path: /reporting/post-processing-svc/status
         initialDelaySeconds: 30
         periodSeconds: 10
         failureThreshold: 5
       liveness:
         enabled: true
-        path: "/reporting/post-processing-svc/status"
+        path: /reporting/post-processing-svc/status
         initialDelaySeconds: 60
         periodSeconds: 30
         failureThreshold: 5
+    image:
+      repository: quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service
+      name: post-processing-reporting-service
+      tag: v1.1.8
+      pullPolicy: IfNotPresent

--- a/charts/rtr/values.yaml
+++ b/charts/rtr/values.yaml
@@ -7,14 +7,14 @@ env: prod              # Environment indicator
 timezone: UTC          # Container timezone
 
 jdbc:
-  username: "nbs_ods"
-  password: "ods"
+  username: ""
+  password: ""
 
 odse:
-  dburl: "jdbc:sqlserver://cdc-nbs-fts3-rds-mssql.czklgy8jnptr.us-east-1.rds.amazonaws.com:1433;databaseName=NBS_ODSE;encrypt=true;trustServerCertificate=true;"
+  dburl: ""
 
 kafka:
-  cluster: "b-2.cdcnbsfts3development.fm0nf5.c12.kafka.us-east-1.amazonaws.com:9094,b-1.cdcnbsfts3development.fm0nf5.c12.kafka.us-east-1.amazonaws.com:9094"
+  cluster: ""
 
 serviceAccount:
   create: true
@@ -229,7 +229,7 @@ services:
       name: ''
       annotations: {}
     rdb:
-      dburl: "jdbc:sqlserver://cdc-nbs-fts3-rds-mssql.czklgy8jnptr.us-east-1.rds.amazonaws.com:1433;databaseName=rdb_modern;encrypt=true;trustServerCertificate=true;"
+      dburl: ""
     log:
       path: /usr/share/post-processing-reporting/data
     probes:

--- a/charts/rtr/values.yaml
+++ b/charts/rtr/values.yaml
@@ -5,7 +5,7 @@ jdbc:
   username: 'nbs_ods'
   password: 'ods'
 odse:
-  dburl: 'jdbc:sqlserver://nbs-db.private-dts1.nbspreview.com:1433;databaseName=rdb_modern;encrypt=true;trustServerCertificate=true'
+  dburl: 'jdbc:sqlserver://nbs-db.private-dts1.nbspreview.com:1433;databaseName=NBS_ODSE;encrypt=true;trustServerCertificate=true'
 kafka:
   cluster: 'b-1.nrtreportingdebezium.89ln12.c11.kafka.us-east-1.amazonaws.com:9092,b-2.nrtreportingdebezium.89ln12.c11.kafka.us-east-1.amazonaws.com:9092'
 serviceAccount:
@@ -193,7 +193,7 @@ services:
       name: ''
       annotations: {}
     rdb:
-      dburl: ''
+      dburl: 'jdbc:sqlserver://nbs-db.private-dts1.nbspreview.com:1433;databaseName=rdb_modern;encrypt=true;trustServerCertificate=true;'
     log:
       path: /usr/share/post-processing-reporting/data
     probes:

--- a/charts/rtr/values.yaml
+++ b/charts/rtr/values.yaml
@@ -63,7 +63,7 @@ services:
         periodSeconds: 30
         failureThreshold: 5
     image:
-      repository: quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service
+      repository: 501715613725.dkr.ecr.us-east-1.amazonaws.com//cdc-nbs-modernization/data-reporting-service
       name: investigation-reporting-service
       tag: 1.0.1-SNAPSHOT.9459a0c
       pullPolicy: IfNotPresent
@@ -91,7 +91,7 @@ services:
         periodSeconds: 30
         failureThreshold: 5
     image:
-      repository: quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service
+      repository: 501715613725.dkr.ecr.us-east-1.amazonaws.com/cdc-nbs-modernization/data-reporting-service
       name: ldfdata-reporting-service
       tag: 1.0.1-SNAPSHOT.9459a0c
       pullPolicy: IfNotPresent
@@ -119,7 +119,7 @@ services:
         periodSeconds: 30
         failureThreshold: 5
     image:
-      repository: quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service
+      repository: 501715613725.dkr.ecr.us-east-1.amazonaws.com/cdc-nbs-modernization/data-reporting-service
       name: observation-reporting-service
       tag: 1.0.1-SNAPSHOT.9459a0c
       pullPolicy: IfNotPresent
@@ -147,7 +147,7 @@ services:
         periodSeconds: 30
         failureThreshold: 5
     image:
-      repository: quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service
+      repository: 501715613725.dkr.ecr.us-east-1.amazonaws.com/cdc-nbs-modernization/data-reporting-service
       name: organization-reporting-service
       tag: 1.0.1-SNAPSHOT.9459a0c
       pullPolicy: IfNotPresent
@@ -175,7 +175,7 @@ services:
         periodSeconds: 30
         failureThreshold: 5
     image:
-      repository: quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service
+      repository: 501715613725.dkr.ecr.us-east-1.amazonaws.com/cdc-nbs-modernization/data-reporting-service
       name: person-reporting-service
       tag: 1.0.1-SNAPSHOT.9459a0c
       pullPolicy: IfNotPresent
@@ -210,7 +210,7 @@ services:
         periodSeconds: 30
         failureThreshold: 5
     image:
-      repository: quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service
+      repository: 501715613725.dkr.ecr.us-east-1.amazonaws.com/cdc-nbs-modernization/data-reporting-service
       name: post-processing-reporting-service
       tag: 1.0.1-SNAPSHOT.9459a0c
       pullPolicy: IfNotPresent

--- a/charts/rtr/values.yaml
+++ b/charts/rtr/values.yaml
@@ -2,12 +2,12 @@ replicaCount: 1
 env: prod
 timezone: UTC
 jdbc:
-  username: 'nbs_ods'
-  password: 'ods'
+  username: ''
+  password: ''
 odse:
-  dburl: 'jdbc:sqlserver://nbs-db.private-dts1.nbspreview.com:1433;databaseName=NBS_ODSE;encrypt=true;trustServerCertificate=true'
+  dburl: ''
 kafka:
-  cluster: 'b-1.nrtreportingdebezium.89ln12.c11.kafka.us-east-1.amazonaws.com:9092,b-2.nrtreportingdebezium.89ln12.c11.kafka.us-east-1.amazonaws.com:9092'
+  cluster: ''
 serviceAccount:
   create: true
   annotations: {}
@@ -193,7 +193,7 @@ services:
       name: ''
       annotations: {}
     rdb:
-      dburl: 'jdbc:sqlserver://nbs-db.private-dts1.nbspreview.com:1433;databaseName=rdb_modern;encrypt=true;trustServerCertificate=true;'
+      dburl: ''
     log:
       path: /usr/share/post-processing-reporting/data
     probes:

--- a/charts/rtr/values.yaml
+++ b/charts/rtr/values.yaml
@@ -65,7 +65,7 @@ services:
     image:
       repository: quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service
       name: investigation-reporting-service
-      tag: v1.1.8
+      tag: 1.0.1-SNAPSHOT.9459a0c
       pullPolicy: IfNotPresent
   ldfdata-reporting:
     service:
@@ -93,7 +93,7 @@ services:
     image:
       repository: quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service
       name: ldfdata-reporting-service
-      tag: v1.1.8
+      tag: 1.0.1-SNAPSHOT.9459a0c
       pullPolicy: IfNotPresent
   observation-reporting:
     service:
@@ -121,7 +121,7 @@ services:
     image:
       repository: quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service
       name: observation-reporting-service
-      tag: v1.1.8
+      tag: 1.0.1-SNAPSHOT.9459a0c
       pullPolicy: IfNotPresent
   organization-reporting:
     service:
@@ -149,7 +149,7 @@ services:
     image:
       repository: quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service
       name: organization-reporting-service
-      tag: v1.1.8
+      tag: 1.0.1-SNAPSHOT.9459a0c
       pullPolicy: IfNotPresent
   person-reporting:
     service:
@@ -177,7 +177,7 @@ services:
     image:
       repository: quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service
       name: person-reporting-service
-      tag: v1.1.8
+      tag: 1.0.1-SNAPSHOT.9459a0c
       pullPolicy: IfNotPresent
     featureFlag:
       elasticSearchEnable: 'true'
@@ -212,6 +212,6 @@ services:
     image:
       repository: quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service
       name: post-processing-reporting-service
-      tag: v1.1.8
+      tag: 1.0.1-SNAPSHOT.9459a0c
       pullPolicy: IfNotPresent
     featureFlag:

--- a/charts/rtr/values.yaml
+++ b/charts/rtr/values.yaml
@@ -196,10 +196,6 @@ services:
       dburl: ''
     log:
       path: /usr/share/post-processing-reporting/data
-<<<<<<< HEAD
-    featureFlag:
-=======
->>>>>>> dc749740 (updated deployment yaml with feature flag)
     probes:
       readiness:
         enabled: true
@@ -219,4 +215,3 @@ services:
       tag: v1.1.8
       pullPolicy: IfNotPresent
     featureFlag:
-      covidDmEnable: 'false'

--- a/charts/rtr/values.yaml
+++ b/charts/rtr/values.yaml
@@ -1,0 +1,233 @@
+# -----------------------------
+# Global/shared configuration
+# -----------------------------
+replicaCount: 1
+env: "prod"
+timezone: "UTC"
+
+image:
+  repository: "quay.io/us-cdcgov/cdc-nbs-modernization/data-reporting-service"
+  tag: "v1.1.8"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+jdbc:
+  username: ""
+  password: ""
+
+odse:
+  dburl: ""
+
+
+kafka:
+  cluster: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/path: "/actuator/prometheus"
+  prometheus.io/port: "8081"
+
+resources: 
+  limits:
+    memory: "512Mi"  
+    cpu: "250m"      
+  requests:
+    memory: "256Mi"  
+    cpu: "125m"
+    
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+probes:
+  readiness:
+    enabled: true
+  liveness:
+    enabled: true
+
+# -----------------------------
+# Per-service configuration
+# -----------------------------
+services:
+
+  investigation-reporting:
+    service:
+      port: 8093
+      httpsPort: 443
+
+    serviceAccount:
+      create: true
+      name: ""          # Optional, leave empty to auto-generate
+      annotations: {}
+
+    featureFlag:
+      phcDatamartEnable: "true"
+      bmirdCaseEnable: "true"
+      contactRecordEnable: "true"
+      treatmentEnable: "false"
+
+    log:
+      path: "/usr/share/investigation-reporting/data"
+
+    probes:
+      readiness:
+        enabled: true
+        path: "/reporting/investigation-svc/status"
+        initialDelaySeconds: 30
+        periodSeconds: 10
+        failureThreshold: 5
+      liveness:
+        enabled: true
+        path: "/reporting/investigation-svc/status"
+        initialDelaySeconds: 60
+        periodSeconds: 30
+        failureThreshold: 5
+
+  ldfdata-reporting:
+    service:
+      port: 8097
+      httpsPort: 443
+
+    serviceAccount:
+      create: true
+      name: ""          # Optional, leave empty to auto-generate
+      annotations: {}
+
+    log:
+      path: "/usr/share/ldfdata-reporting/data"
+    probes:
+      readiness:
+        enabled: true
+        path: "/reporting/ldfdata-svc/status"
+        initialDelaySeconds: 30
+        periodSeconds: 10
+        failureThreshold: 5
+      liveness:
+        enabled: true
+        path: "/reporting/ldfdata-svc/status"
+        initialDelaySeconds: 60
+        periodSeconds: 30
+        failureThreshold: 5
+
+  observation-reporting:
+    service:
+      port: 8094
+      httpsPort: 443
+
+    serviceAccount:
+      create: true
+      name: ""          # Optional, leave empty to auto-generate
+      annotations: {}
+
+    log:
+      path: "/usr/share/observation-reporting/data"
+
+    probes:
+      readiness:
+        enabled: true
+        path: "/reporting/observation-svc/status"
+        initialDelaySeconds: 30
+        periodSeconds: 10
+        failureThreshold: 5
+      liveness:
+        enabled: true
+        path: "/reporting/observation-svc/status"
+        initialDelaySeconds: 60
+        periodSeconds: 30
+        failureThreshold: 5
+
+  organization-reporting:
+    service:
+      port: 8092
+      httpsPort: 443
+
+    serviceAccount:
+      create: true
+      name: ""          # Optional, leave empty to auto-generate
+      annotations: {}
+
+    log:
+      path: "/usr/share/organization-reporting/data"
+
+    probes:
+      readiness:
+        enabled: true
+        path: "/reporting/organization-svc/status"
+        initialDelaySeconds: 30
+        periodSeconds: 10
+        failureThreshold: 5
+      liveness:
+        enabled: true
+        path: "/reporting/organization-svc/status"
+        initialDelaySeconds: 60
+        periodSeconds: 30
+        failureThreshold: 5
+
+  person-reporting:
+    service:
+      port: 8091
+      httpsPort: 443
+
+    serviceAccount:
+      create: true
+      name: ""          # Optional, leave empty to auto-generate
+      annotations: {}
+
+    log:
+      path: "/usr/share/person-reporting/data"
+    probes:
+      readiness:
+        enabled: true
+        path: "/reporting/person-svc/status"
+        initialDelaySeconds: 30
+        periodSeconds: 10
+        failureThreshold: 5
+      liveness:
+        enabled: true
+        path: "/reporting/person-svc/status"
+        initialDelaySeconds: 60
+        periodSeconds: 30
+        failureThreshold: 5
+
+  post-processing-reporting:
+    service:
+      port: 8095
+      httpsPort: 443
+      fixedDelay:
+        cachedIds: 2
+
+    serviceAccount:
+      create: true
+      name: ""          # Optional, leave empty to auto-generate
+      annotations: {}
+    rdb:
+        dburl: ""
+    log:
+        path: "/usr/share/post-processing-reporting/data"
+    featureFlag:
+      covidDmEnable: "false"
+    probes:
+      readiness:
+        enabled: true
+        path: "/reporting/post-processing-svc/status"
+        initialDelaySeconds: 30
+        periodSeconds: 10
+        failureThreshold: 5
+      liveness:
+        enabled: true
+        path: "/reporting/post-processing-svc/status"
+        initialDelaySeconds: 60
+        periodSeconds: 30
+        failureThreshold: 5

--- a/charts/rtr/values.yaml
+++ b/charts/rtr/values.yaml
@@ -63,7 +63,7 @@ services:
         periodSeconds: 30
         failureThreshold: 5
     image:
-      repository: 501715613725.dkr.ecr.us-east-1.amazonaws.com//cdc-nbs-modernization/data-reporting-service
+      repository: 501715613725.dkr.ecr.us-east-1.amazonaws.com/cdc-nbs-modernization/data-reporting-service
       name: investigation-reporting-service
       tag: 1.0.1-SNAPSHOT.9459a0c
       pullPolicy: IfNotPresent

--- a/charts/rtr/values.yaml
+++ b/charts/rtr/values.yaml
@@ -1,42 +1,63 @@
+# ================================================
+# Global configuration
+# ================================================
+
 replicaCount: 1
-env: prod
-timezone: UTC
+env: prod              # Environment indicator
+timezone: UTC          # Container timezone
+
 jdbc:
-  username: ''
-  password: ''
+  username: ''         # DB username (should be set in secrets)
+  password: ''         # DB password (should be set in secrets)
+
 odse:
-  dburl: ''
+  dburl: ''            # ODSE DB URL
+
 kafka:
-  cluster: ''
+  cluster: ''          # Kafka cluster bootstrap servers
+
 serviceAccount:
   create: true
   annotations: {}
   name: ''
+
 podAnnotations:
   prometheus.io/scrape: 'true'
   prometheus.io/path: /actuator/prometheus
   prometheus.io/port: '8081'
+
 resources:
   limits:
-    memory: 1Gi
-    cpu: 500m
+    memory: 1Gi        # Memory limit per pod
+    cpu: 500m          # CPU limit per pod
   requests:
-    memory: 512Mi
-    cpu: 250m
+    memory: 512Mi      # Memory request per pod
+    cpu: 250m          # CPU request per pod
+
 autoscaling:
   enabled: false
   minReplicas: 1
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
+
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
 probes:
   readiness:
-    enabled: true
+    enabled: true      # Enable readiness probe
   liveness:
-    enabled: true
+    enabled: true      # Enable liveness probe
+
+# ================================================
+# Service-specific configurations
+# ================================================
 services:
+
+  # ----------------------------------------
+  # Investigation Reporting Service
+  # ----------------------------------------
   investigation-reporting:
     service:
       port: 8093
@@ -67,6 +88,10 @@ services:
       name: investigation-reporting-service
       tag: 1.0.1-SNAPSHOT.9459a0c
       pullPolicy: IfNotPresent
+
+  # ----------------------------------------
+  # LDF Data Reporting Service
+  # ----------------------------------------
   ldfdata-reporting:
     service:
       port: 8097
@@ -95,6 +120,10 @@ services:
       name: ldfdata-reporting-service
       tag: 1.0.1-SNAPSHOT.9459a0c
       pullPolicy: IfNotPresent
+
+  # ----------------------------------------
+  # Observation Reporting Service
+  # ----------------------------------------
   observation-reporting:
     service:
       port: 8094
@@ -123,6 +152,10 @@ services:
       name: observation-reporting-service
       tag: 1.0.1-SNAPSHOT.9459a0c
       pullPolicy: IfNotPresent
+
+  # ----------------------------------------
+  # Organization Reporting Service
+  # ----------------------------------------
   organization-reporting:
     service:
       port: 8092
@@ -151,6 +184,10 @@ services:
       name: organization-reporting-service
       tag: 1.0.1-SNAPSHOT.9459a0c
       pullPolicy: IfNotPresent
+
+  # ----------------------------------------
+  # Person Reporting Service
+  # ----------------------------------------
   person-reporting:
     service:
       port: 8091
@@ -159,6 +196,9 @@ services:
       create: true
       name: ''
       annotations: {}
+    featureFlag:
+      elasticSearchEnable: 'true'
+      covidDmEnable: 'false'
     log:
       path: /usr/share/person-reporting/data
     probes:
@@ -179,9 +219,10 @@ services:
       name: person-reporting-service
       tag: 1.0.1-SNAPSHOT.9459a0c
       pullPolicy: IfNotPresent
-    featureFlag:
-      elasticSearchEnable: 'true'
-      covidDmEnable: 'false'
+
+  # ----------------------------------------
+  # Post-Processing Reporting Service
+  # ----------------------------------------
   post-processing-reporting:
     service:
       port: 8095

--- a/charts/rtr/values.yaml
+++ b/charts/rtr/values.yaml
@@ -215,3 +215,4 @@ services:
       tag: 1.0.1-SNAPSHOT.9459a0c
       pullPolicy: IfNotPresent
     featureFlag:
+      covidDmEnable: 'false'

--- a/charts/rtr/values.yaml
+++ b/charts/rtr/values.yaml
@@ -28,11 +28,11 @@ podAnnotations:
 
 resources:
   limits:
-    memory: 1Gi        # Memory limit per pod
-    cpu: 500m          # CPU limit per pod
+    memory: ''         # User should set
+    cpu: ''            # User should set
   requests:
-    memory: 512Mi      # Memory request per pod
-    cpu: 250m          # CPU request per pod
+    memory: ''         # User should set
+    cpu: ''            # User should set
 
 autoscaling:
   enabled: false
@@ -63,7 +63,6 @@ services:
       port: 8093
       httpsPort: 443
     serviceAccount:
-      create: true
       name: ''
       annotations: {}
     featureFlag:
@@ -84,9 +83,9 @@ services:
         periodSeconds: 30
         failureThreshold: 5
     image:
-      repository: 501715613725.dkr.ecr.us-east-1.amazonaws.com/cdc-nbs-modernization/data-reporting-service
-      name: investigation-reporting-service
-      tag: 1.0.1-SNAPSHOT.9459a0c
+      repository: ''
+      name: ''
+      tag: ''
       pullPolicy: IfNotPresent
 
   # ----------------------------------------
@@ -97,7 +96,6 @@ services:
       port: 8097
       httpsPort: 443
     serviceAccount:
-      create: true
       name: ''
       annotations: {}
     log:
@@ -116,9 +114,9 @@ services:
         periodSeconds: 30
         failureThreshold: 5
     image:
-      repository: 501715613725.dkr.ecr.us-east-1.amazonaws.com/cdc-nbs-modernization/data-reporting-service
-      name: ldfdata-reporting-service
-      tag: 1.0.1-SNAPSHOT.9459a0c
+      repository: ''
+      name: ''
+      tag: ''
       pullPolicy: IfNotPresent
 
   # ----------------------------------------
@@ -129,7 +127,6 @@ services:
       port: 8094
       httpsPort: 443
     serviceAccount:
-      create: true
       name: ''
       annotations: {}
     log:
@@ -148,9 +145,9 @@ services:
         periodSeconds: 30
         failureThreshold: 5
     image:
-      repository: 501715613725.dkr.ecr.us-east-1.amazonaws.com/cdc-nbs-modernization/data-reporting-service
-      name: observation-reporting-service
-      tag: 1.0.1-SNAPSHOT.9459a0c
+      repository: ''
+      name: ''
+      tag: ''
       pullPolicy: IfNotPresent
 
   # ----------------------------------------
@@ -161,7 +158,6 @@ services:
       port: 8092
       httpsPort: 443
     serviceAccount:
-      create: true
       name: ''
       annotations: {}
     log:
@@ -180,9 +176,9 @@ services:
         periodSeconds: 30
         failureThreshold: 5
     image:
-      repository: 501715613725.dkr.ecr.us-east-1.amazonaws.com/cdc-nbs-modernization/data-reporting-service
-      name: organization-reporting-service
-      tag: 1.0.1-SNAPSHOT.9459a0c
+      repository: ''
+      name: ''
+      tag: ''
       pullPolicy: IfNotPresent
 
   # ----------------------------------------
@@ -193,7 +189,6 @@ services:
       port: 8091
       httpsPort: 443
     serviceAccount:
-      create: true
       name: ''
       annotations: {}
     featureFlag:
@@ -215,9 +210,9 @@ services:
         periodSeconds: 30
         failureThreshold: 5
     image:
-      repository: 501715613725.dkr.ecr.us-east-1.amazonaws.com/cdc-nbs-modernization/data-reporting-service
-      name: person-reporting-service
-      tag: 1.0.1-SNAPSHOT.9459a0c
+      repository: ''
+      name: ''
+      tag: ''
       pullPolicy: IfNotPresent
 
   # ----------------------------------------
@@ -230,7 +225,6 @@ services:
       fixedDelay:
         cachedIds: 2
     serviceAccount:
-      create: true
       name: ''
       annotations: {}
     rdb:
@@ -251,9 +245,9 @@ services:
         periodSeconds: 30
         failureThreshold: 5
     image:
-      repository: 501715613725.dkr.ecr.us-east-1.amazonaws.com/cdc-nbs-modernization/data-reporting-service
-      name: post-processing-reporting-service
-      tag: 1.0.1-SNAPSHOT.9459a0c
+      repository: ''
+      name: ''
+      tag: ''
       pullPolicy: IfNotPresent
     featureFlag:
       covidDmEnable: 'false'


### PR DESCRIPTION
## Description

Please include a summary of the changes and any key information a reviewer may need. Review the appropriate section below.


## Creating a new Helm chart?
1. Does the service require an ingress?
    - Kubernetes Ingress resource are PATH based and only handled by modernization-api and dataingestion-service helm charts. 
    - Currently, names of Kubernetes services have to be predictable if an ingress needs to point to them
2. Chart directory structure (specific environment values.yaml files are allowed at the same level as values.yaml)
    ```  
    |── charts
        ├── new-helm-chart
            ├── templates
            |   ├── tests
            |   ├── helpers.tpl
            |   ├── *.yaml
            |   └─ Chart.yaml
            ├── values.yaml
            └─  README.md
    ```    
3. **Do not include secret values anywhere in a Helm chart, take special care when creating values.yaml**
4. values.yaml is annotated to include parameter description and format as appropriate.
    - values.yaml is considered the production/default parameter file and should point to publically available container registries, if the service is publically available.    

## Updating a Helm Chart?
1. Ensure no secrets have been committed.
2. Ensure updates to existing Helm charts follow the guidelines contained in section [Creating a new Helm chart](#creating-a-new-helm-chart).

