### PR TITLE
Keycloak health check updated to port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *values*-az-*.yaml
 *-argocd-*.yaml
 *.DS_STORE
+mt-*-argocd-*.yaml
+internal-*-argocd-*.yaml
+mt-*-values-*.yaml

--- a/charts/keycloak/templates/deployment.yaml
+++ b/charts/keycloak/templates/deployment.yaml
@@ -43,8 +43,7 @@ spec:
 
         {{- if .Values.probes.readiness.enabled | default "false"  }}
         readinessProbe:
-          httpGet:
-            path: {{ .Values.probes.readiness.path | default "/auth" }}
+          tcpSocket:
             port: {{ .Values.probes.readiness.port | default "8080" }}
           initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds | default "60" }}
           periodSeconds: {{ .Values.probes.readiness.periodSeconds | default "30" }}
@@ -53,8 +52,7 @@ spec:
 
         {{- if .Values.probes.liveness.enabled | default "false"  }}
         livenessProbe:
-          httpGet:
-            path: {{ .Values.probes.liveness.path | default "/auth" }}
+          tcpSocket:
             port: {{ .Values.probes.liveness.port | default "8080" }}
           initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds | default "120" }}
           periodSeconds: {{ .Values.probes.liveness.periodSeconds | default "60" }}


### PR DESCRIPTION
## Description

Please include a summary of the changes and any key information a reviewer may need. Review the appropriate section below.


## Creating a new Helm chart?
1. Does the service require an ingress?
    - Kubernetes Ingress resource are PATH based and only handled by modernization-api and dataingestion-service helm charts. 
    - Currently, names of Kubernetes services have to be predictable if an ingress needs to point to them
2. Chart directory structure (specific environment values.yaml files are allowed at the same level as values.yaml)
    ```  
    |── charts
        ├── new-helm-chart
            ├── templates
            |   ├── tests
            |   ├── helpers.tpl
            |   ├── *.yaml
            |   └─ Chart.yaml
            ├── values.yaml
            └─  README.md
    ```    
3. **Do not include secret values anywhere in a Helm chart, take special care when creating values.yaml**
4. values.yaml is annotated to include parameter description and format as appropriate.
    - values.yaml is considered the production/default parameter file and should point to publically available container registries, if the service is publically available.    

## Updating a Helm Chart?
1. Ensure no secrets have been committed.
2. Ensure updates to existing Helm charts follow the guidelines contained in section [Creating a new Helm chart](#creating-a-new-helm-chart).

