### PR TITLE
DI obr splitter feature flag

### DIFF
--- a/charts/dataingestion-service/templates/deployment.yaml
+++ b/charts/dataingestion-service/templates/deployment.yaml
@@ -90,7 +90,7 @@ spec:
             - name: API_PAYLOAD_MAX_SIZE
               value: "{{ .Values.apiPayloadMaxSize}}"
             - name: OBR_SPLITTING_ENABLED
-              value: "{{ .Values.features.obrSpliting.enabled}}"
+              value: "{{ .Values.features.obrSplitting.enabled}}"
           volumeMounts:
           - mountPath: /usr/share/dataingestion/data
             name: di-persistent-storage     

--- a/charts/dataingestion-service/templates/deployment.yaml
+++ b/charts/dataingestion-service/templates/deployment.yaml
@@ -89,6 +89,8 @@ spec:
               value: "{{ .Values.kafkaConcurrency}}"
             - name: API_PAYLOAD_MAX_SIZE
               value: "{{ .Values.apiPayloadMaxSize}}"
+            - name: OBR_SPLITTING_ENABLED
+              value: "{{ .Values.features.obrSpliting.enabled}}"
           volumeMounts:
           - mountPath: /usr/share/dataingestion/data
             name: di-persistent-storage     

--- a/charts/dataingestion-service/values-dts1.yaml
+++ b/charts/dataingestion-service/values-dts1.yaml
@@ -5,7 +5,7 @@ env: "dts1"
 image:
   repository: ""
   pullPolicy: IfNotPresent
-  tag: 1.0.1-SNAPSHOT.eca3418
+  tag: 1.0.1-SNAPSHOT-flag.c2cca31
 
 imagePullSecrets: []
 nameOverride: ""
@@ -132,6 +132,10 @@ sftp:
   elrFileExtns: "txt,hl7"
   filePaths: "/"
 # filePaths value should be comma seperated like "/,/LAB-1,/lab-2, /lab-2/lab2-sub-folder"
+
+features:
+  obrSpliting:
+    enabled: "false"
 
 kafkaConcurrency: "1"
 

--- a/charts/dataingestion-service/values-dts1.yaml
+++ b/charts/dataingestion-service/values-dts1.yaml
@@ -5,7 +5,7 @@ env: "dts1"
 image:
   repository: ""
   pullPolicy: IfNotPresent
-  tag: 1.0.1-SNAPSHOT-flag.c2cca31
+  tag: 1.0.1-SNAPSHOT-batch.1e2a6fc
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/dataingestion-service/values-dts1.yaml
+++ b/charts/dataingestion-service/values-dts1.yaml
@@ -134,7 +134,7 @@ sftp:
 # filePaths value should be comma seperated like "/,/LAB-1,/lab-2, /lab-2/lab2-sub-folder"
 
 features:
-  obrSpliting:
+  obrSplitting:
     enabled: "false"
 
 kafkaConcurrency: "1"

--- a/charts/dataingestion-service/values-feature.yaml
+++ b/charts/dataingestion-service/values-feature.yaml
@@ -135,7 +135,12 @@ sftp:
   host: ""
   username: ""
   password: ""
+  elrFileExtns: "txt,hl7"
+  filePaths: "/"
 
+features:
+  obrSplitting:
+    enabled: "false"
 
 apiPayloadMaxSize: "100MB"
 

--- a/charts/dataingestion-service/values-int1.yaml
+++ b/charts/dataingestion-service/values-int1.yaml
@@ -137,6 +137,12 @@ sftp:
   host: ""
   username: ""
   password: ""
+  elrFileExtns: "txt,hl7"
+  filePaths: "/"
+
+features:
+  obrSplitting:
+    enabled: "false"
 
 kafkaConcurrency: "1"
 apiPayloadMaxSize: "100MB"

--- a/charts/dataingestion-service/values.yaml
+++ b/charts/dataingestion-service/values.yaml
@@ -138,6 +138,9 @@ sftp:
   filePaths: "/"  
 # filePaths value should be comma seperated like "/,/LAB-1,/lab-2,/lab-2/lab2-sub-folder"
 ##################################
+features:
+  obrSplitting:
+    enabled: "false"
 
 apiPayloadMaxSize: "100MB"
 


### PR DESCRIPTION
## Description

Added feature flag to enable/disable the OBR splitter in the DI service. Default is disabled.

## Creating a new Helm chart?
1. Does the service require an ingress?
    - Kubernetes Ingress resource are PATH based and only handled by modernization-api and dataingestion-service helm charts. 
    - Currently, names of Kubernetes services have to be predictable if an ingress needs to point to them
2. Chart directory structure (specific environment values.yaml files are allowed at the same level as values.yaml)
    ```  
    |── charts
        ├── new-helm-chart
            ├── templates
            |   ├── tests
            |   ├── helpers.tpl
            |   ├── *.yaml
            |   └─ Chart.yaml
            ├── values.yaml
            └─  README.md
    ```    
3. **Do not include secret values anywhere in a Helm chart, take special care when creating values.yaml**
4. values.yaml is annotated to include parameter description and format as appropriate.
    - values.yaml is considered the production/default parameter file and should point to publically available container registries, if the service is publically available.    

## Updating a Helm Chart?
1. Ensure no secrets have been committed.
2. Ensure updates to existing Helm charts follow the guidelines contained in section [Creating a new Helm chart](#creating-a-new-helm-chart).

