### PR TITLE
Remove deduplication-api ingress

### DIFF
--- a/charts/modernization-api/templates/ingress.yaml
+++ b/charts/modernization-api/templates/ingress.yaml
@@ -63,13 +63,6 @@ spec:
                 name: nbs-gateway-svc  #nbs-gateway-ext
                 port:
                   number: {{ .Values.service.gatewayPort }} #443
-          - path: "/nbs/api/deduplication/"
-            pathType: Prefix
-            backend:
-              service:
-                name: deduplication-api
-                port:
-                  name: https
           - path: "/"
             pathType: Prefix
             backend:


### PR DESCRIPTION
## Description

Removes the deduplication-api ingress as all access to the api should route through the nbs-gateway.