### PR TITLE
Added values for Nifi and Elasticsearch

### DIFF
--- a/argocd/templates/elasticsearch.yaml
+++ b/argocd/templates/elasticsearch.yaml
@@ -35,6 +35,10 @@ spec:
           value: {{ .Values.elasticsearch.podRequestMemory }}
         - name: resources.limits.memory
           value: {{ .Values.elasticsearch.podLimitMemory }}
+        - name: azure.files.storageRequest
+          value: {{ .Values.elasticsearch.storageRequest }}
+        - name: pvc.esPvClaim.storageRequest
+          value: {{ .Values.elasticsearch.storageRequest }}
   syncPolicy:
     automated:
       prune: true

--- a/argocd/templates/nifi.yaml
+++ b/argocd/templates/nifi.yaml
@@ -52,7 +52,11 @@ spec:
         - name: resources.requests.memory
           value: {{ .Values.nifi.podRequestMemory }}
         - name: resources.limits.memory
-          value: {{ .Values.nifi.podLimitMemory }}       
+          value: {{ .Values.nifi.podLimitMemory }}
+        - name: jvmheap.init
+          value: {{ .Values.nifi.jvmheapInit }}    
+        - name: jvmheap.max
+          value: {{ .Values.nifi.jvmheapMax }}         
   syncPolicy:
     automated:
       prune: true 

--- a/argocd/values.yaml
+++ b/argocd/values.yaml
@@ -94,6 +94,7 @@ debezium-case-notifications:
 
 
 elasticsearch:
+  storageRequest: <UPDATE_STORAGE_REQUEST>
   podRequestCPU: <UPDATE_POD_REQUEST_CPU>
   podLimitCPU: <UPDATE_POD_LIMIT_CPU>
   podRequestMemory: <UPDATE_POD_REQUEST_MEMORY>
@@ -165,6 +166,8 @@ nifi:
   sensitivePropsKey: <UPDATE_SENSITIVE_PROPS_KEY>
   ephemeralStorageRequest: <UPDATE_EPHEMERAL_STORAGE_REQUEST>
   ephemeralStorageLimit: <UPDATE_EPHEMERAL_STORAGE_LIMIT>
+  jvmheapInit: <UPDATE_JVM_HEAP_INIT>
+  jvmheapMax: <UPDATE_JVM_HEAP_MAX>
   podRequestCPU: <UPDATE_POD_REQUEST_CPU>
   podLimitCPU: <UPDATE_POD_LIMIT_CPU>
   podRequestMemory: <UPDATE_POD_REQUEST_MEMORY>


### PR DESCRIPTION
## Description

Please include a summary of the changes and any key information a reviewer may need. Review the appropriate section below.


## Creating a new Helm chart?
1. Does the service require an ingress?
    - Kubernetes Ingress resource are PATH based and only handled by modernization-api and dataingestion-service helm charts. 
    - Currently, names of Kubernetes services have to be predictable if an ingress needs to point to them
2. Chart directory structure (specific environment values.yaml files are allowed at the same level as values.yaml)
    ```  
    |── charts
        ├── new-helm-chart
            ├── templates
            |   ├── tests
            |   ├── helpers.tpl
            |   ├── *.yaml
            |   └─ Chart.yaml
            ├── values.yaml
            └─  README.md
    ```    
3. **Do not include secret values anywhere in a Helm chart, take special care when creating values.yaml**
4. values.yaml is annotated to include parameter description and format as appropriate.
    - values.yaml is considered the production/default parameter file and should point to publically available container registries, if the service is publically available.    

## Updating a Helm Chart?
1. Ensure no secrets have been committed.
2. Ensure updates to existing Helm charts follow the guidelines contained in section [Creating a new Helm chart](#creating-a-new-helm-chart).

