### PR TITLE
added dataingestion feature flags to argocd

### DIFF
--- a/argocd/templates/dataingestion-service.yaml
+++ b/argocd/templates/dataingestion-service.yaml
@@ -59,6 +59,10 @@ spec:
         value: {{ .Values.dataIngestionService.podRequestMemory }}
       - name: resources.limits.memory
         value: {{ .Values.dataIngestionService.podLimitMemory }}
+      - name: features.obrSplitting.enabled
+        value: {{ .Values.dataIngestionService.obrSplittingEnabled }}
+      - name: features.hl7BatchSplitting.enabled
+        value: {{ .Values.dataIngestionService.hl7BatchSplitting.Enabled }}
   syncPolicy:
     automated:
       prune: true

--- a/argocd/values.yaml
+++ b/argocd/values.yaml
@@ -78,6 +78,8 @@ dataIngestionService:
   podLimitCPU: <UPDATE_POD_LIMIT_CPU>
   podRequestMemory: <UPDATE_POD_REQUEST_MEMORY>
   podLimitMemory: <UPDATE_POD_LIMIT_MEMORY>
+  obrSplittingEnabled: <UPDATE_DI_OBRSPLITTINGENABLE>
+  hl7BatchSplitting.Enabled: <UPDATE_DI_HL7VBATCHSPLITTINGENABLE>
 
 
 debezium:


### PR DESCRIPTION
## Description

Please include a summary of the changes and any key information a reviewer may need. Review the appropriate section below.


## Creating a new Helm chart?
1. Does the service require an ingress?
    - Kubernetes Ingress resource are PATH based and only handled by modernization-api and dataingestion-service helm charts. 
    - Currently, names of Kubernetes services have to be predictable if an ingress needs to point to them
2. Chart directory structure (specific environment values.yaml files are allowed at the same level as values.yaml)
    ```  
    |── charts
        ├── new-helm-chart
            ├── templates
            |   ├── tests
            |   ├── helpers.tpl
            |   ├── *.yaml
            |   └─ Chart.yaml
            ├── values.yaml
            └─  README.md
    ```    
3. **Do not include secret values anywhere in a Helm chart, take special care when creating values.yaml**
4. values.yaml is annotated to include parameter description and format as appropriate.
    - values.yaml is considered the production/default parameter file and should point to publically available container registries, if the service is publically available.    

## Updating a Helm Chart?
1. Ensure no secrets have been committed.
2. Ensure updates to existing Helm charts follow the guidelines contained in section [Creating a new Helm chart](#creating-a-new-helm-chart).

