### PR TITLE
[CNDE-2602] Adding new env var to DI Service

### DIFF
--- a/charts/dataingestion-service/templates/deployment.yaml
+++ b/charts/dataingestion-service/templates/deployment.yaml
@@ -89,6 +89,8 @@ spec:
               value: "{{ .Values.kafkaConcurrency}}"
             - name: API_PAYLOAD_MAX_SIZE
               value: "{{ .Values.apiPayloadMaxSize}}"
+            - name: SPRING_PROFILES_ACTIVE
+              value: "{{ .Values.springBootProfile}}"
             - name: OBR_SPLITTING_ENABLED
               value: {{ .Values.features.obrSplitting.enabled | default false | quote}}
             - name: HL7_BATCH_SPLITTING_ENABLED

--- a/charts/dataingestion-service/values-dev.yaml
+++ b/charts/dataingestion-service/values-dev.yaml
@@ -123,6 +123,8 @@ efsFileSystemId: "EXAMPLE_EFS_ID"
 
 authUri: ""
 
+springBootProfile: "dev"
+
 # Override available for readiness and liveness probes: port, initialDelaySeconds, periodSeconds, failureThreshold
 probes:
   readiness:

--- a/charts/dataingestion-service/values-dts1.yaml
+++ b/charts/dataingestion-service/values-dts1.yaml
@@ -143,6 +143,8 @@ kafkaConcurrency: "1"
 
 apiPayloadMaxSize: "100MB"
 
+springBootProfile: "dev"
+
 # Override available for readiness and liveness probes: port, initialDelaySeconds, periodSeconds, failureThreshold
 probes:
   readiness:

--- a/charts/dataingestion-service/values-feature.yaml
+++ b/charts/dataingestion-service/values-feature.yaml
@@ -146,6 +146,8 @@ features:
 
 apiPayloadMaxSize: "100MB"
 
+springBootProfile: "dev"
+
 # Override available for readiness and liveness probes: port, initialDelaySeconds, periodSeconds, failureThreshold
 probes:
   readiness:

--- a/charts/dataingestion-service/values-int1.yaml
+++ b/charts/dataingestion-service/values-int1.yaml
@@ -149,6 +149,8 @@ features:
 kafkaConcurrency: "1"
 apiPayloadMaxSize: "100MB"
 
+springBootProfile: "dev"
+
 # Override available for readiness and liveness probes: port, initialDelaySeconds, periodSeconds, failureThreshold
 probes:
   readiness:

--- a/charts/dataingestion-service/values-test2.yaml
+++ b/charts/dataingestion-service/values-test2.yaml
@@ -147,6 +147,8 @@ features:
 kafkaConcurrency: "1"
 apiPayloadMaxSize: "100MB"
 
+springBootProfile: "dev"
+
 # Override available for readiness and liveness probes: port, initialDelaySeconds, periodSeconds, failureThreshold
 probes:
   readiness:

--- a/charts/dataingestion-service/values.yaml
+++ b/charts/dataingestion-service/values.yaml
@@ -146,8 +146,6 @@ features:
 
 apiPayloadMaxSize: "100MB"
 
-springBootProfile: "dev"
-
 # Override available for readiness and liveness probes: path, port, initialDelaySeconds, periodSeconds, failureThreshold
 probes:
   readiness:

--- a/charts/dataingestion-service/values.yaml
+++ b/charts/dataingestion-service/values.yaml
@@ -146,6 +146,8 @@ features:
 
 apiPayloadMaxSize: "100MB"
 
+springBootProfile: "dev"
+
 # Override available for readiness and liveness probes: path, port, initialDelaySeconds, periodSeconds, failureThreshold
 probes:
   readiness:


### PR DESCRIPTION
## Description

This PR contains the changes to add new env var to the Data Ingestion service that will let us turn on and off swagger in the upper envs.

`SPRING_PROFILES_ACTIVE=dev` -> Swagger on
`SPRING_PROFILES_ACTIVE=default` -> Swagger off


## Creating a new Helm chart?
1. Does the service require an ingress?
    - Kubernetes Ingress resource are PATH based and only handled by modernization-api and dataingestion-service helm charts. 
    - Currently, names of Kubernetes services have to be predictable if an ingress needs to point to them
2. Chart directory structure (specific environment values.yaml files are allowed at the same level as values.yaml)
    ```  
    |── charts
        ├── new-helm-chart
            ├── templates
            |   ├── tests
            |   ├── helpers.tpl
            |   ├── *.yaml
            |   └─ Chart.yaml
            ├── values.yaml
            └─  README.md
    ```    
3. **Do not include secret values anywhere in a Helm chart, take special care when creating values.yaml**
4. values.yaml is annotated to include parameter description and format as appropriate.
    - values.yaml is considered the production/default parameter file and should point to publically available container registries, if the service is publically available.    

## Updating a Helm Chart?
1. Ensure no secrets have been committed.
2. Ensure updates to existing Helm charts follow the guidelines contained in section [Creating a new Helm chart](#creating-a-new-helm-chart).

