### PR TITLE
[CNDE-2602] Added new env variable to Case Notifications

### DIFF
--- a/charts/case-notification-service/templates/deployment.yaml
+++ b/charts/case-notification-service/templates/deployment.yaml
@@ -60,3 +60,5 @@ spec:
               value: {{ .Values.api.secret}}
             - name: NND_DE_URL
               value: {{ .Values.api.host}}
+            - name: SPRING_PROFILES_ACTIVE
+              value: "{{ .Values.springBootProfile}}"

--- a/charts/case-notification-service/values-demo.yaml
+++ b/charts/case-notification-service/values-demo.yaml
@@ -51,6 +51,8 @@ affinity: {}
 
 ingressHost: "dataingestion.demo.nbspreview.com"
 
+springBootProfile: "dev"
+
 kafka:
   cluster: ""
 

--- a/charts/case-notification-service/values-dts1.yaml
+++ b/charts/case-notification-service/values-dts1.yaml
@@ -55,6 +55,8 @@ affinity: {}
 
 ingressHost: "dataingestion.dts1.nbspreview.com"
 
+springBootProfile: "dev"
+
 kafka:
   cluster: ""
 

--- a/charts/case-notification-service/values-feature.yaml
+++ b/charts/case-notification-service/values-feature.yaml
@@ -57,6 +57,8 @@ affinity: {}
 
 ingressHost: "dataingestion.feature.nbspreview.com"
 
+springBootProfile: "dev"
+
 kafka:
   cluster: ""
 

--- a/charts/case-notification-service/values-int1.yaml
+++ b/charts/case-notification-service/values-int1.yaml
@@ -56,6 +56,8 @@ affinity: {}
 
 ingressHost: "dataingestion.int1.nbspreview.com"
 
+springBootProfile: "dev"
+
 kafka:
   cluster: ""
 

--- a/charts/case-notification-service/values-test2.yaml
+++ b/charts/case-notification-service/values-test2.yaml
@@ -56,6 +56,8 @@ affinity: {}
 
 ingressHost: "dataingestion.test.nbspreview.com"
 
+springBootProfile: "dev"
+
 kafka:
   cluster: ""
 

--- a/charts/xml-hl7-parser-service/templates/deployment.yaml
+++ b/charts/xml-hl7-parser-service/templates/deployment.yaml
@@ -48,3 +48,5 @@ spec:
               value: {{ .Values.jdbc.password }}
             - name: CN_SERVER_HOST
               value: {{ .Values.ingressHost }}
+            - name: SPRING_PROFILES_ACTIVE
+              value: "{{ .Values.springBootProfile}}"

--- a/charts/xml-hl7-parser-service/values-demo.yaml
+++ b/charts/xml-hl7-parser-service/values-demo.yaml
@@ -51,6 +51,8 @@ affinity: {}
 
 ingressHost: "dataingestion.demo.nbspreview.com"
 
+springBootProfile: "dev"
+
 jdbc:
   dbserver: ""
   username: ""

--- a/charts/xml-hl7-parser-service/values-dts1.yaml
+++ b/charts/xml-hl7-parser-service/values-dts1.yaml
@@ -55,6 +55,8 @@ affinity: {}
 
 ingressHost: "dataingestion.dts1.nbspreview.com"
 
+springBootProfile: "dev"
+
 jdbc:
   dbserver: ""
   username: ""

--- a/charts/xml-hl7-parser-service/values-feature.yaml
+++ b/charts/xml-hl7-parser-service/values-feature.yaml
@@ -57,6 +57,8 @@ affinity: {}
 
 ingressHost: "dataingestion.feature.nbspreview.com"
 
+springBootProfile: "dev"
+
 jdbc:
   dbserver: ""
   username: ""

--- a/charts/xml-hl7-parser-service/values-int1.yaml
+++ b/charts/xml-hl7-parser-service/values-int1.yaml
@@ -56,6 +56,8 @@ affinity: {}
 
 ingressHost: "dataingestion.int1.nbspreview.com"
 
+springBootProfile: "dev"
+
 jdbc:
   dbserver: ""
   username: ""

--- a/charts/xml-hl7-parser-service/values-test2.yaml
+++ b/charts/xml-hl7-parser-service/values-test2.yaml
@@ -56,6 +56,8 @@ affinity: {}
 
 ingressHost: "dataingestion.test.nbspreview.com"
 
+springBootProfile: "dev"
+
 jdbc:
   dbserver: ""
   username: ""


### PR DESCRIPTION
## Description

This PR contains the changes to add new env var to the Data Ingestion service that will let us turn on and off swagger in the upper envs.

`SPRING_PROFILES_ACTIVE=dev` -> Swagger on
`SPRING_PROFILES_ACTIVE=default` -> Swagger off


## Creating a new Helm chart?
1. Does the service require an ingress?
    - Kubernetes Ingress resource are PATH based and only handled by modernization-api and dataingestion-service helm charts. 
    - Currently, names of Kubernetes services have to be predictable if an ingress needs to point to them
2. Chart directory structure (specific environment values.yaml files are allowed at the same level as values.yaml)
    ```  
    |── charts
        ├── new-helm-chart
            ├── templates
            |   ├── tests
            |   ├── helpers.tpl
            |   ├── *.yaml
            |   └─ Chart.yaml
            ├── values.yaml
            └─  README.md
    ```    
3. **Do not include secret values anywhere in a Helm chart, take special care when creating values.yaml**
4. values.yaml is annotated to include parameter description and format as appropriate.
    - values.yaml is considered the production/default parameter file and should point to publically available container registries, if the service is publically available.    

## Updating a Helm Chart?
1. Ensure no secrets have been committed.
2. Ensure updates to existing Helm charts follow the guidelines contained in section [Creating a new Helm chart](#creating-a-new-helm-chart).

