### PR TITLE
[CNDE-2602] Added new env variable to NNDSS

### DIFF
--- a/charts/nnd-service/templates/deployment.yaml
+++ b/charts/nnd-service/templates/deployment.yaml
@@ -73,6 +73,8 @@ spec:
               value: {{ .Values.authUri }}
             - name: NND_LOG_PATH
               value: {{ .Values.log.path }}
+            - name: SPRING_PROFILES_ACTIVE
+              value: "{{ .Values.springBootProfile}}"
 
           volumeMounts:
           - mountPath: /usr/share/nndservice/data

--- a/charts/nnd-service/values-demo.yaml
+++ b/charts/nnd-service/values-demo.yaml
@@ -55,6 +55,8 @@ jdbc:
 
 authUri: ""
 
+springBootProfile: "dev"
+
 log:
   path: "/usr/share/nndservice/data"
 

--- a/charts/nnd-service/values-dts1.yaml
+++ b/charts/nnd-service/values-dts1.yaml
@@ -56,6 +56,8 @@ jdbc:
 
 authUri: ""
 
+springBootProfile: "dev"
+
 log:
   path: "/usr/share/nndservice/data"
 

--- a/charts/nnd-service/values-feature.yaml
+++ b/charts/nnd-service/values-feature.yaml
@@ -59,6 +59,8 @@ jdbc:
 
 authUri: ""
 
+springBootProfile: "dev"
+
 log:
   path: "/usr/share/nndservice/data"
 

--- a/charts/nnd-service/values-int1.yaml
+++ b/charts/nnd-service/values-int1.yaml
@@ -59,6 +59,8 @@ jdbc:
 
 authUri: ""
 
+springBootProfile: "dev"
+
 log:
   path: "/usr/share/nndservice/data"
 

--- a/charts/nnd-service/values-test2.yaml
+++ b/charts/nnd-service/values-test2.yaml
@@ -59,6 +59,8 @@ jdbc:
 
 authUri: ""
 
+springBootProfile: "dev"
+
 log:
   path: "/usr/share/nndservice/data"
 


### PR DESCRIPTION
## Description

This PR contains the changes to add new env var to the Data Ingestion service that will let us turn on and off swagger in the upper envs.

`SPRING_PROFILES_ACTIVE=dev` -> Swagger on
`SPRING_PROFILES_ACTIVE=default` -> Swagger off


## Creating a new Helm chart?
1. Does the service require an ingress?
    - Kubernetes Ingress resource are PATH based and only handled by modernization-api and dataingestion-service helm charts. 
    - Currently, names of Kubernetes services have to be predictable if an ingress needs to point to them
2. Chart directory structure (specific environment values.yaml files are allowed at the same level as values.yaml)
    ```  
    |── charts
        ├── new-helm-chart
            ├── templates
            |   ├── tests
            |   ├── helpers.tpl
            |   ├── *.yaml
            |   └─ Chart.yaml
            ├── values.yaml
            └─  README.md
    ```    
3. **Do not include secret values anywhere in a Helm chart, take special care when creating values.yaml**
4. values.yaml is annotated to include parameter description and format as appropriate.
    - values.yaml is considered the production/default parameter file and should point to publically available container registries, if the service is publically available.    

## Updating a Helm Chart?
1. Ensure no secrets have been committed.
2. Ensure updates to existing Helm charts follow the guidelines contained in section [Creating a new Helm chart](#creating-a-new-helm-chart).

