### PR TITLE
Added profile flag for DP

### DIFF
--- a/charts/data-processing-service/templates/deployment.yaml
+++ b/charts/data-processing-service/templates/deployment.yaml
@@ -115,6 +115,8 @@ spec:
               value: "{{ .Values.hikari.maxLifeTime }}"
             - name: LEAK_DETECTION_THRESHOLD
               value: "{{ .Values.hikari.leakDetectThresHold }}"
+            - name: SPRING_PROFILES_ACTIVE
+              value: "{{ .Values.springBootProfile}}"
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/data-processing-service/values-demo.yaml
+++ b/charts/data-processing-service/values-demo.yaml
@@ -82,3 +82,6 @@ probes:
     enabled: true
   liveness:
     enabled: true
+
+
+springBootProfile: "prod"

--- a/charts/data-processing-service/values-dts1.yaml
+++ b/charts/data-processing-service/values-dts1.yaml
@@ -117,3 +117,6 @@ uid:
   minPoolSize: "1000"
 
 timezone: "UTC"
+
+
+springBootProfile: "dev"

--- a/charts/data-processing-service/values-feature.yaml
+++ b/charts/data-processing-service/values-feature.yaml
@@ -119,3 +119,5 @@ uid:
   minPoolSize: "1000"
 
 timezone: "UTC"
+
+springBootProfile: "dev"

--- a/charts/data-processing-service/values-fts1.yaml
+++ b/charts/data-processing-service/values-fts1.yaml
@@ -94,3 +94,5 @@ probes:
     enabled: true
   liveness:
     enabled: true
+
+springBootProfile: "prod"

--- a/charts/data-processing-service/values-int1.yaml
+++ b/charts/data-processing-service/values-int1.yaml
@@ -117,3 +117,5 @@ uid:
   minPoolSize: "1000"
 
 timezone: "UTC"
+
+springBootProfile: "dev"

--- a/charts/data-processing-service/values-test2.yaml
+++ b/charts/data-processing-service/values-test2.yaml
@@ -117,3 +117,5 @@ uid:
   minPoolSize: "1000"
 
 timezone: "UTC"
+
+springBootProfile: "dev"

--- a/charts/data-processing-service/values.yaml
+++ b/charts/data-processing-service/values.yaml
@@ -109,3 +109,5 @@ uid:
   minPoolSize: "1000"
 
 timezone: "UTC"
+
+springBootProfile: ""


### PR DESCRIPTION
## Description

Please include a summary of the changes and any key information a reviewer may need. Review the appropriate section below.


## Creating a new Helm chart?
1. Does the service require an ingress?
    - Kubernetes Ingress resource are PATH based and only handled by modernization-api and dataingestion-service helm charts. 
    - Currently, names of Kubernetes services have to be predictable if an ingress needs to point to them
2. Chart directory structure (specific environment values.yaml files are allowed at the same level as values.yaml)
    ```  
    |── charts
        ├── new-helm-chart
            ├── templates
            |   ├── tests
            |   ├── helpers.tpl
            |   ├── *.yaml
            |   └─ Chart.yaml
            ├── values.yaml
            └─  README.md
    ```    
3. **Do not include secret values anywhere in a Helm chart, take special care when creating values.yaml**
4. values.yaml is annotated to include parameter description and format as appropriate.
    - values.yaml is considered the production/default parameter file and should point to publically available container registries, if the service is publically available.    

## Updating a Helm Chart?
1. Ensure no secrets have been committed.
2. Ensure updates to existing Helm charts follow the guidelines contained in section [Creating a new Helm chart](#creating-a-new-helm-chart).

