### PR TITLE
add autoexec update pass

### DIFF
--- a/charts/sas-linux/templates/cron.yaml
+++ b/charts/sas-linux/templates/cron.yaml
@@ -35,7 +35,16 @@ spec:
               sed -i -e "s/<NBS_RDB_PASS>/$rdb_pass/g" /home/SAS/.odbc.ini;
               cp /home/SAS/.odbc.ini /etc/odbc.ini;
               chmod 766 /etc/odbc.ini;
-              export ODBCINI=/etc/odbc.ini       
+              export ODBCINI=/etc/odbc.ini;              
+              echo "Updating autoexec.sas";
+              autoexec_home="${WILDFLY_HOME}/wildfly-10.0.0.Final/nedssdomain/Nedss/report";
+              sed -i "s|SAS_REPORT_HOME=.*|SAS_REPORT_HOME=$autoexec_home;|g" "$autoexec_home/autoexec.sas";
+              sed -i "s|DSN=nedss1.*PASSWORD=.*s|DSN=nedss1 UID=$odse_user PASSWORD=$odse_pass|g" "$autoexec_home/autoexec.sas";
+              sed -i "s|DSN=nbs_rdb.*PASSWORD=.*b|DSN=nbs_rdb UID=$rdb_user PASSWORD=$rdb_pass|g" "$autoexec_home/autoexec.sas";
+              sed -i "s|DSN=nbs_srt.*PASSWORD=.*s|DSN=nbs_srt UID=$odse_user PASSWORD=$odse_pass|g" "$autoexec_home/autoexec.sas";
+              sed -i "s|DSN=nbs_msg.*PASSWORD=.*s|DSN=nbs_msg UID=$odse_user PASSWORD=$odse_pass|g" "$autoexec_home/autoexec.sas";
+              sed -i "s|let username=.*|let username=\"$rdb_user\";|g" "$autoexec_home/autoexec.sas";
+              sed -i "s|let password=.*|let password=\"$rdb_pass\";|g" "$autoexec_home/autoexec.sas";       
               date;              
               echo 'Running PHCMartETL.sh';
               $WILDFLY_HOME/wildfly-10.0.0.Final/nedssdomain/Nedss/BatchFiles/PHCMartETL.sh;


### PR DESCRIPTION
## Description

Adding autoexec update from devops


## Creating a new Helm chart?
1. Does the service require an ingress?
    - Kubernetes Ingress resource are PATH based and only handled by modernization-api and dataingestion-service helm charts. 
    - Currently, names of Kubernetes services have to be predictable if an ingress needs to point to them
2. Chart directory structure (specific environment values.yaml files are allowed at the same level as values.yaml)
    ```  
    |── charts
        ├── new-helm-chart
            ├── templates
            |   ├── tests
            |   ├── helpers.tpl
            |   ├── *.yaml
            |   └─ Chart.yaml
            ├── values.yaml
            └─  README.md
    ```    
3. **Do not include secret values anywhere in a Helm chart, take special care when creating values.yaml**
4. values.yaml is annotated to include parameter description and format as appropriate.
    - values.yaml is considered the production/default parameter file and should point to publically available container registries, if the service is publically available.    

## Updating a Helm Chart?
1. Ensure no secrets have been committed.
2. Ensure updates to existing Helm charts follow the guidelines contained in section [Creating a new Helm chart](#creating-a-new-helm-chart).

