### PR TITLE
[CNDE-3135] Added azure config for data compare service

### DIFF
--- a/charts/data-compare-api-service/templates/deployment.yaml
+++ b/charts/data-compare-api-service/templates/deployment.yaml
@@ -52,6 +52,16 @@ spec:
               value: {{ .Values.s3.bucketName }}
             - name: S3_REGION
               value: {{ .Values.s3.region }}
+            - name: AZURE_STORAGE_ACCOUNT_NAME
+              value: {{ .Values.azure.storageAccountName }}
+            - name: AZURE_CONTAINER_NAME
+              value: {{ .Values.azure.containerName }}
+            - name: AZURE_CONNECTION_STRING
+              value: {{ .Values.azure.connectionString }}
+            - name: AZURE_SAS_TOKEN
+              value: {{ .Values.azure.sasToken }}
+            - name: AZURE_MANAGED_IDENTITY
+              value: {{ .Values.azure.managedIdentity.enabled | quote }}
             - name: KAFKA_BOOTSTRAP_SERVER
               value: {{ .Values.kafka.cluster }}  
           resources:

--- a/charts/data-compare-api-service/templates/pvc-az.yaml
+++ b/charts/data-compare-api-service/templates/pvc-az.yaml
@@ -1,0 +1,15 @@
+{{- if eq .Values.cloudProvider "azure" }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "data-compare-api-service.fullname" . }}-dc-pvc
+  labels:
+  {{- include "data-compare-api-service.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.azure.files.storageRequest | quote }}
+  storageClassName: {{ .Values.azure.files.storageClass | quote }}
+{{- end }}

--- a/charts/data-compare-api-service/templates/pvc-efs.yaml
+++ b/charts/data-compare-api-service/templates/pvc-efs.yaml
@@ -1,0 +1,15 @@
+{{- if eq .Values.cloudProvider "aws" }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "data-compare-api-service.fullname" . }}-dc-pvc
+  labels:
+  {{- include "data-compare-api-service.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.pvc.dcPvClaim.storageRequest | quote }}
+  storageClassName: {{ .Values.pvc.dcPvClaim.storageClass | quote }}
+{{- end }}

--- a/charts/data-compare-api-service/templates/storageclass-az.yaml
+++ b/charts/data-compare-api-service/templates/storageclass-az.yaml
@@ -1,0 +1,24 @@
+{{- if eq .Values.cloudProvider "azure" }}
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: {{ .Values.azure.files.storageClass | quote }}
+provisioner: file.csi.azure.com # replace with "kubernetes.io/azure-file" if aks version is less than 1.21
+allowVolumeExpansion: true
+mountOptions:
+ - dir_mode=0777
+ - file_mode=0777
+ - uid=0
+ - gid=0
+ - mfsymlinks
+ - cache=strict
+ - actimeo=30
+ - nobrl  # disable sending byte range lock requests to the server and for applications which have challenges with posix locks
+parameters:
+  skuName: Standard_LRS
+  #location: us-east-1
+  resourceGroup: {{ .Values.azure.files.resourceGroupName | quote }}
+  storageAccount: {{ .Values.azure.files.storageAccountName | quote }}
+  #customEndpoint: cselsnbsdelowmainacc-file
+  shareName: nbs-datacompareapi
+{{- end }}

--- a/charts/data-compare-api-service/templates/storageclass.yaml
+++ b/charts/data-compare-api-service/templates/storageclass.yaml
@@ -1,0 +1,11 @@
+{{- if eq .Values.cloudProvider "aws" }}
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: {{ .Values.pvc.dcPvClaim.storageClass | quote }}
+provisioner: efs.csi.aws.com
+parameters:
+  provisioningMode: efs-ap
+  fileSystemId: {{ .Values.efsFileSystemId | quote }}
+  directoryPerms: "700"
+{{- end }}

--- a/charts/data-compare-api-service/values-azure.yaml
+++ b/charts/data-compare-api-service/values-azure.yaml
@@ -62,7 +62,17 @@ authUri: ""
 kafka:
   cluster: "wn0-dev-hd.dsnw3omymczu3cea2rtxoridtc.bx.internal.cloudapp.net:9092,wn1-dev-hd.dsnw3omymczu3cea2rtxoridtc.bx.internal.cloudapp.net:9092,wn2-dev-hd.dsnw3omymczu3cea2rtxoridtc.bx.internal.cloudapp.net:9092"
 
+log:
+  path: "/usr/share/datacompareapi/data"
+
+cloudProvider: azure
+
 azure:
+  files:
+    resourceGroupName: 
+    storageAccountName: 
+    storageClass: azurefile-csi-private-datacompareapi
+    storageRequest: 20Gi
   storageAccountName: "AZURE_STORAGE_ACCOUNT_NAME"
   containerName: "AZURE_CONTAINER_NAME"
   connectionString: "AZURE_CONNECTION_STRING"
@@ -70,12 +80,5 @@ azure:
   managedIdentity:
     enabled: false
 
-log:
-  path: "/usr/share/datacompareapi/data"
 
-pvc:
-  dcPvClaim:
-    storageClass: azurefile-csi-private-datacompareapi
-    storageRequest: 20Gi
-
-azureFileShareName: ""
+efsFileSystemId: "EXAMPLE_EFS_ID"

--- a/charts/data-compare-api-service/values-azure.yaml
+++ b/charts/data-compare-api-service/values-azure.yaml
@@ -1,0 +1,81 @@
+replicaCount: 1
+
+env: "azure"
+
+image:
+  repository: "quay.io/us-cdcgov/cdc-nbs-modernization/data-compare-api-service"
+  pullPolicy: IfNotPresent
+  tag: "v1.0.7"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/path: "/actuator/prometheus"
+  prometheus.io/port: "8098"
+
+podSecurityContext: {}
+
+securityContext: {}
+
+service:
+  type: ClusterIP
+  port: 8085
+  httpsPort: 443
+
+resources:
+  limits:
+    memory: "2Gi"
+    cpu: "1000m"
+  requests:
+    memory: "1Gi"
+    cpu: "500m"
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+ingressHost: "data.azure.example.com"
+
+jdbc:
+  dbserver: "tf-cdc-nbs6-sql-managed-instance.cdf5734b998e.database.windows.net"
+  username: "nbs_ods"
+  password: ""
+
+authUri: ""
+
+kafka:
+  cluster: "wn0-dev-hd.dsnw3omymczu3cea2rtxoridtc.bx.internal.cloudapp.net:9092,wn1-dev-hd.dsnw3omymczu3cea2rtxoridtc.bx.internal.cloudapp.net:9092,wn2-dev-hd.dsnw3omymczu3cea2rtxoridtc.bx.internal.cloudapp.net:9092"
+
+azure:
+  storageAccountName: "AZURE_STORAGE_ACCOUNT_NAME"
+  containerName: "AZURE_CONTAINER_NAME"
+  connectionString: "AZURE_CONNECTION_STRING"
+  sasToken: "AZURE_SAS_TOKEN"
+  managedIdentity:
+    enabled: false
+
+log:
+  path: "/usr/share/datacompareapi/data"
+
+pvc:
+  dcPvClaim:
+    storageClass: azurefile-csi-private-datacompareapi
+    storageRequest: 20Gi
+
+azureFileShareName: ""

--- a/charts/data-compare-api-service/values-azure.yaml
+++ b/charts/data-compare-api-service/values-azure.yaml
@@ -50,17 +50,18 @@ tolerations: []
 
 affinity: {}
 
-ingressHost: "data.azure.example.com"
+ingressHost: "data.EXAMPLE_DOMAIN"
 
+# dbserver is passed in as an environment variable. It is just the database endpoint
 jdbc:
-  dbserver: "tf-cdc-nbs6-sql-managed-instance.cdf5734b998e.database.windows.net"
-  username: "nbs_ods"
-  password: ""
+  dbserver: "EXAMPLE_DB_ENDPOINT"
+  username: "EXAMPLE_ODSE_DB_USER"
+  password: "EXAMPLE_ODSE_DB_USER_PASSWORD"
 
 authUri: ""
 
 kafka:
-  cluster: "wn0-dev-hd.dsnw3omymczu3cea2rtxoridtc.bx.internal.cloudapp.net:9092,wn1-dev-hd.dsnw3omymczu3cea2rtxoridtc.bx.internal.cloudapp.net:9092,wn2-dev-hd.dsnw3omymczu3cea2rtxoridtc.bx.internal.cloudapp.net:9092"
+  cluster: "EXAMPLE_MSK_KAFKA_ENDPOINT"
 
 log:
   path: "/usr/share/datacompareapi/data"

--- a/charts/data-compare-api-service/values-azure.yaml
+++ b/charts/data-compare-api-service/values-azure.yaml
@@ -65,8 +65,6 @@ kafka:
 log:
   path: "/usr/share/datacompareapi/data"
 
-cloudProvider: azure
-
 azure:
   files:
     resourceGroupName: 
@@ -80,5 +78,10 @@ azure:
   managedIdentity:
     enabled: false
 
+#AWS PVC Settings#
+pvc:
+  dcPvClaim:
+    storageClass: efs-datacompareapi
+    storageRequest: 20Gi
 
 efsFileSystemId: "EXAMPLE_EFS_ID"

--- a/charts/data-compare-api-service/values.yaml
+++ b/charts/data-compare-api-service/values.yaml
@@ -54,6 +54,9 @@ jdbc:
 
 authUri: ""
 
+kafka:
+  cluster: "EXAMPLE_MSK_KAFKA_ENDPOINT"
+
 log:
   path: "/usr/share/datacompareapi/data"
 

--- a/charts/data-compare-processor-service/templates/deployment.yaml
+++ b/charts/data-compare-processor-service/templates/deployment.yaml
@@ -52,6 +52,16 @@ spec:
               value: {{ .Values.s3.bucketName }}
             - name: S3_REGION
               value: {{ .Values.s3.region }}
+            - name: AZURE_STORAGE_ACCOUNT_NAME
+              value: {{ .Values.azure.storageAccountName }}
+            - name: AZURE_CONTAINER_NAME
+              value: {{ .Values.azure.containerName }}
+            - name: AZURE_CONNECTION_STRING
+              value: {{ .Values.azure.connectionString }}
+            - name: AZURE_SAS_TOKEN
+              value: {{ .Values.azure.sasToken }}
+            - name: AZURE_MANAGED_IDENTITY
+              value: {{ .Values.azure.managedIdentity.enabled | quote }}
             - name: KAFKA_BOOTSTRAP_SERVER
               value: {{ .Values.kafka.cluster }}
             - name: RECIPIENT_EMAILS

--- a/charts/data-compare-processor-service/templates/pvc-az.yaml
+++ b/charts/data-compare-processor-service/templates/pvc-az.yaml
@@ -1,0 +1,15 @@
+{{- if eq .Values.cloudProvider "azure" }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "data-compare-processor-service.fullname" . }}-dc-pvc
+  labels:
+  {{- include "data-compare-processor-service.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.azure.files.storageRequest | quote }}
+  storageClassName: {{ .Values.azure.files.storageClass | quote }}
+{{- end }}

--- a/charts/data-compare-processor-service/templates/pvc-efs.yaml
+++ b/charts/data-compare-processor-service/templates/pvc-efs.yaml
@@ -1,0 +1,15 @@
+{{- if eq .Values.cloudProvider "aws" }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "data-compare-processor-service.fullname" . }}-dc-pvc
+  labels:
+  {{- include "data-compare-processor-service.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.pvc.dcPvClaim.storageRequest | quote }}
+  storageClassName: {{ .Values.pvc.dcPvClaim.storageClass | quote }}
+{{- end }}

--- a/charts/data-compare-processor-service/templates/storageclass-az.yaml
+++ b/charts/data-compare-processor-service/templates/storageclass-az.yaml
@@ -1,0 +1,24 @@
+{{- if eq .Values.cloudProvider "azure" }}
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: {{ .Values.azure.files.storageClass | quote }}
+provisioner: file.csi.azure.com # replace with "kubernetes.io/azure-file" if aks version is less than 1.21
+allowVolumeExpansion: true
+mountOptions:
+ - dir_mode=0777
+ - file_mode=0777
+ - uid=0
+ - gid=0
+ - mfsymlinks
+ - cache=strict
+ - actimeo=30
+ - nobrl  # disable sending byte range lock requests to the server and for applications which have challenges with posix locks
+parameters:
+  skuName: Standard_LRS
+  #location: us-east-1
+  resourceGroup: {{ .Values.azure.files.resourceGroupName | quote }}
+  storageAccount: {{ .Values.azure.files.storageAccountName | quote }}
+  #customEndpoint: cselsnbsdelowmainacc-file
+  shareName: nbs-datacompareprocessor
+{{- end }}

--- a/charts/data-compare-processor-service/templates/storageclass.yaml
+++ b/charts/data-compare-processor-service/templates/storageclass.yaml
@@ -1,0 +1,11 @@
+{{- if eq .Values.cloudProvider "aws" }}
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: {{ .Values.pvc.dcPvClaim.storageClass | quote }}
+provisioner: efs.csi.aws.com
+parameters:
+  provisioningMode: efs-ap
+  fileSystemId: {{ .Values.efsFileSystemId | quote }}
+  directoryPerms: "700"
+{{- end }}

--- a/charts/data-compare-processor-service/values-azure.yaml
+++ b/charts/data-compare-processor-service/values-azure.yaml
@@ -65,8 +65,6 @@ kafka:
 log:
   path: "/usr/share/datacompareprocessor/data"
 
-cloudProvider: azure
-
 #Azure PVC Settings#
 azure:
   files:
@@ -80,6 +78,12 @@ azure:
   sasToken: "AZURE_SAS_TOKEN"
   managedIdentity:
     enabled: false
+
+#AWS PVC Settings#
+pvc:
+  dcPvClaim:
+    storageClass: efs-datacompareprocessor
+    storageRequest: 20Gi
 
 ses:
   recipients: ""

--- a/charts/data-compare-processor-service/values-azure.yaml
+++ b/charts/data-compare-processor-service/values-azure.yaml
@@ -62,10 +62,18 @@ authUri: ""
 kafka:
   cluster: "wn0-dev-hd.dsnw3omymczu3cea2rtxoridtc.bx.internal.cloudapp.net:9092,wn1-dev-hd.dsnw3omymczu3cea2rtxoridtc.bx.internal.cloudapp.net:9092,wn2-dev-hd.dsnw3omymczu3cea2rtxoridtc.bx.internal.cloudapp.net:9092"
 
-ses:
-  recipients: ""
+log:
+  path: "/usr/share/datacompareprocessor/data"
 
+cloudProvider: azure
+
+#Azure PVC Settings#
 azure:
+  files:
+    resourceGroupName: 
+    storageAccountName: 
+    storageClass: azurefile-csi-private-datacompareprocessor
+    storageRequest: 20Gi
   storageAccountName: "AZURE_STORAGE_ACCOUNT_NAME"
   containerName: "AZURE_CONTAINER_NAME"
   connectionString: "AZURE_CONNECTION_STRING"
@@ -73,12 +81,7 @@ azure:
   managedIdentity:
     enabled: false
 
-log:
-  path: "/usr/share/datacompareprocessor/data"
+ses:
+  recipients: ""
 
-pvc:
-  dcPvClaim:
-    storageClass: azurefile-csi-private-datacompareprocessor
-    storageRequest: 20Gi
-
-azureFileShareName: ""
+efsFileSystemId: "EXAMPLE_EFS_ID"

--- a/charts/data-compare-processor-service/values-azure.yaml
+++ b/charts/data-compare-processor-service/values-azure.yaml
@@ -1,0 +1,84 @@
+replicaCount: 1
+
+env: "azure"
+
+image:
+  repository: "quay.io/us-cdcgov/cdc-nbs-modernization/data-compare-processor-service"
+  pullPolicy: IfNotPresent
+  tag: "v1.0.7"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/path: "/actuator/prometheus"
+  prometheus.io/port: "8098"
+
+podSecurityContext: {}
+
+securityContext: {}
+
+service:
+  type: ClusterIP
+  port: 8086
+  httpsPort: 443
+
+resources:
+  limits:
+    memory: "2Gi"
+    cpu: "1000m"
+  requests:
+    memory: "1Gi"
+    cpu: "500m"
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+ingressHost: "data.azure.example.com"
+
+jdbc:
+  dbserver: "tf-cdc-nbs6-sql-managed-instance.cdf5734b998e.database.windows.net"
+  username: "nbs_ods"
+  password: ""
+
+authUri: ""
+
+kafka:
+  cluster: "wn0-dev-hd.dsnw3omymczu3cea2rtxoridtc.bx.internal.cloudapp.net:9092,wn1-dev-hd.dsnw3omymczu3cea2rtxoridtc.bx.internal.cloudapp.net:9092,wn2-dev-hd.dsnw3omymczu3cea2rtxoridtc.bx.internal.cloudapp.net:9092"
+
+ses:
+  recipients: ""
+
+azure:
+  storageAccountName: "AZURE_STORAGE_ACCOUNT_NAME"
+  containerName: "AZURE_CONTAINER_NAME"
+  connectionString: "AZURE_CONNECTION_STRING"
+  sasToken: "AZURE_SAS_TOKEN"
+  managedIdentity:
+    enabled: false
+
+log:
+  path: "/usr/share/datacompareprocessor/data"
+
+pvc:
+  dcPvClaim:
+    storageClass: azurefile-csi-private-datacompareprocessor
+    storageRequest: 20Gi
+
+azureFileShareName: ""

--- a/charts/data-compare-processor-service/values-azure.yaml
+++ b/charts/data-compare-processor-service/values-azure.yaml
@@ -50,17 +50,18 @@ tolerations: []
 
 affinity: {}
 
-ingressHost: "data.azure.example.com"
+ingressHost: "data.EXAMPLE_DOMAIN"
 
+# dbserver is passed in as an environment variable. It is just the database endpoint
 jdbc:
-  dbserver: "tf-cdc-nbs6-sql-managed-instance.cdf5734b998e.database.windows.net"
-  username: "nbs_ods"
-  password: ""
+  dbserver: "EXAMPLE_DB_ENDPOINT"
+  username: "EXAMPLE_ODSE_DB_USER"
+  password: "EXAMPLE_ODSE_DB_USER_PASSWORD"
 
 authUri: ""
 
 kafka:
-  cluster: "wn0-dev-hd.dsnw3omymczu3cea2rtxoridtc.bx.internal.cloudapp.net:9092,wn1-dev-hd.dsnw3omymczu3cea2rtxoridtc.bx.internal.cloudapp.net:9092,wn2-dev-hd.dsnw3omymczu3cea2rtxoridtc.bx.internal.cloudapp.net:9092"
+  cluster: "EXAMPLE_MSK_KAFKA_ENDPOINT"
 
 log:
   path: "/usr/share/datacompareprocessor/data"

--- a/charts/data-compare-processor-service/values.yaml
+++ b/charts/data-compare-processor-service/values.yaml
@@ -54,8 +54,10 @@ jdbc:
   username: ""
   password: ""
 
-#authUri: "http://keycloak.keycloak.svc.cluster.local/realms/NBS"
-authUri: ""
+authUri: "http://keycloak.keycloak.svc.cluster.local/realms/NBS"
+
+kafka:
+  cluster: "EXAMPLE_MSK_KAFKA_ENDPOINT"
 
 log:
   path: "/usr/share/datacompareprocessor/data"


### PR DESCRIPTION
## Description

This PR includes the changes needed to deploy the data compare service to azure environment.


## Creating a new Helm chart?
1. Does the service require an ingress?
    - Kubernetes Ingress resource are PATH based and only handled by modernization-api and dataingestion-service helm charts. 
    - Currently, names of Kubernetes services have to be predictable if an ingress needs to point to them
2. Chart directory structure (specific environment values.yaml files are allowed at the same level as values.yaml)
    ```  
    |── charts
        ├── new-helm-chart
            ├── templates
            |   ├── tests
            |   ├── helpers.tpl
            |   ├── *.yaml
            |   └─ Chart.yaml
            ├── values.yaml
            └─  README.md
    ```    
3. **Do not include secret values anywhere in a Helm chart, take special care when creating values.yaml**
4. values.yaml is annotated to include parameter description and format as appropriate.
    - values.yaml is considered the production/default parameter file and should point to publically available container registries, if the service is publically available.    

## Updating a Helm Chart?
1. Ensure no secrets have been committed.
2. Ensure updates to existing Helm charts follow the guidelines contained in section [Creating a new Helm chart](#creating-a-new-helm-chart).

