### PR TITLE
CNDE-3125: Prometheus metrics to RTR services

### DIFF
--- a/charts/rtr/values-dts1.yaml
+++ b/charts/rtr/values-dts1.yaml
@@ -31,11 +31,6 @@ global:
     annotations: { }
     name: ''
 
-  podAnnotations:
-    prometheus.io/scrape: 'true'
-    prometheus.io/path: /actuator/prometheus
-    prometheus.io/port: '8081'
-
   resources:
     limits:
       memory: "1Gi"
@@ -102,6 +97,10 @@ services:
     image:
       name: "investigation-reporting-service"
       tag: 1.0.1-SNAPSHOT.79df56b
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: /actuator/prometheus
+      prometheus.io/port: '8093'
 
   # ----------------------------------------
   # LDF Data Reporting Service
@@ -172,6 +171,10 @@ services:
     image:
       name: "observation-reporting-service"
       tag: 1.0.1-SNAPSHOT.79df56b
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: /actuator/prometheus
+      prometheus.io/port: '8094'
 
 
   # ----------------------------------------
@@ -208,6 +211,10 @@ services:
     image:
       name: "organization-reporting-service"
       tag: 1.0.1-SNAPSHOT.79df56b
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: /actuator/prometheus
+      prometheus.io/port: '8092'
 
   # ----------------------------------------
   # Person Reporting Service
@@ -246,6 +253,10 @@ services:
     image:
       name: "person-reporting-service"
       tag: 1.0.1-SNAPSHOT.79df56b
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: /actuator/prometheus
+      prometheus.io/port: '8091'
 
   # ----------------------------------------
   # Post-Processing Reporting Service
@@ -283,4 +294,8 @@ services:
     image:
       name: "post-processing-reporting-service"
       tag: 1.0.1-SNAPSHOT.79df56b
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: /actuator/prometheus
+      prometheus.io/port: '8095'
 

--- a/charts/rtr/values-dts1.yaml
+++ b/charts/rtr/values-dts1.yaml
@@ -300,4 +300,3 @@ services:
       prometheus.io/scrape: 'true'
       prometheus.io/path: /actuator/prometheus
       prometheus.io/port: '8095'
-

--- a/charts/rtr/values-dummy.yaml
+++ b/charts/rtr/values-dummy.yaml
@@ -97,10 +97,6 @@ services:
     image:
       name: "investigation-reporting-service"
       tag: "v1.1.9"
-    podAnnotations:
-      prometheus.io/scrape: 'true'
-      prometheus.io/path: /actuator/prometheus
-      prometheus.io/port: '8093'
 
   # ----------------------------------------
   # LDF Data Reporting Service
@@ -172,10 +168,6 @@ services:
     image:
       name: "observation-reporting-service"
       tag: "v1.1.9"
-    podAnnotations:
-      prometheus.io/scrape: 'true'
-      prometheus.io/path: /actuator/prometheus
-      prometheus.io/port: '8094'
 
   # ----------------------------------------
   # Organization Reporting Service
@@ -211,10 +203,6 @@ services:
     image:
       name: "organization-reporting-service"
       tag: "v1.1.9"
-    podAnnotations:
-      prometheus.io/scrape: 'true'
-      prometheus.io/path: /actuator/prometheus
-      prometheus.io/port: '8092'
 
   # ----------------------------------------
   # Person Reporting Service
@@ -252,10 +240,6 @@ services:
     image:
       name: "person-reporting-service"
       tag: "v1.1.9"
-    podAnnotations:
-      prometheus.io/scrape: 'true'
-      prometheus.io/path: /actuator/prometheus
-      prometheus.io/port: '8091'
 
   # ----------------------------------------
   # Post-Processing Reporting Service
@@ -295,7 +279,3 @@ services:
     image:
       name: "post-processing-reporting-service"
       tag: "v1.1.9"
-    podAnnotations:
-      prometheus.io/scrape: 'true'
-      prometheus.io/path: /actuator/prometheus
-      prometheus.io/port: '8095'

--- a/charts/rtr/values-dummy.yaml
+++ b/charts/rtr/values-dummy.yaml
@@ -32,11 +32,6 @@ global:
     annotations: { }
     name: ''
 
-  podAnnotations:
-    prometheus.io/scrape: 'true'
-    prometheus.io/path: /actuator/prometheus
-    prometheus.io/port: '8081'
-
   resources:
     limits:
       memory: "1Gi"
@@ -102,6 +97,10 @@ services:
     image:
       name: "investigation-reporting-service"
       tag: "v1.1.9"
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: /actuator/prometheus
+      prometheus.io/port: '8093'
 
   # ----------------------------------------
   # LDF Data Reporting Service
@@ -173,6 +172,10 @@ services:
     image:
       name: "observation-reporting-service"
       tag: "v1.1.9"
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: /actuator/prometheus
+      prometheus.io/port: '8094'
 
   # ----------------------------------------
   # Organization Reporting Service
@@ -208,6 +211,10 @@ services:
     image:
       name: "organization-reporting-service"
       tag: "v1.1.9"
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: /actuator/prometheus
+      prometheus.io/port: '8092'
 
   # ----------------------------------------
   # Person Reporting Service
@@ -245,6 +252,10 @@ services:
     image:
       name: "person-reporting-service"
       tag: "v1.1.9"
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: /actuator/prometheus
+      prometheus.io/port: '8091'
 
   # ----------------------------------------
   # Post-Processing Reporting Service
@@ -284,3 +295,7 @@ services:
     image:
       name: "post-processing-reporting-service"
       tag: "v1.1.9"
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: /actuator/prometheus
+      prometheus.io/port: '8095'

--- a/charts/rtr/values.yaml
+++ b/charts/rtr/values.yaml
@@ -94,10 +94,6 @@ services:
     image:
       name: "investigation-reporting-service"
       tag: "v1.2.0"
-    podAnnotations:
-      prometheus.io/scrape: 'true'
-      prometheus.io/path: /actuator/prometheus
-      prometheus.io/port: '8093'
 
   # ----------------------------------------
   # LDF Data Reporting Service
@@ -169,10 +165,6 @@ services:
     image:
       name: "observation-reporting-service"
       tag: "v1.2.0"
-    podAnnotations:
-      prometheus.io/scrape: 'true'
-      prometheus.io/path: /actuator/prometheus
-      prometheus.io/port: '8094'
 
   # ----------------------------------------
   # Organization Reporting Service
@@ -208,10 +200,6 @@ services:
     image:
       name: "organization-reporting-service"
       tag: "v1.2.0"
-    podAnnotations:
-      prometheus.io/scrape: 'true'
-      prometheus.io/path: /actuator/prometheus
-      prometheus.io/port: '8092'
 
   # ----------------------------------------
   # Person Reporting Service
@@ -249,10 +237,6 @@ services:
     image:
       name: "person-reporting-service"
       tag: "v1.2.0"
-    podAnnotations:
-      prometheus.io/scrape: 'true'
-      prometheus.io/path: /actuator/prometheus
-      prometheus.io/port: '8091'
 
   # ----------------------------------------
   # Post-Processing Reporting Service
@@ -292,7 +276,3 @@ services:
     image:
       name: "post-processing-reporting-service"
       tag: "v1.2.0"
-    podAnnotations:
-      prometheus.io/scrape: 'true'
-      prometheus.io/path: /actuator/prometheus
-      prometheus.io/port: '8095'

--- a/charts/rtr/values.yaml
+++ b/charts/rtr/values.yaml
@@ -29,11 +29,6 @@ global:
     annotations: { }
     name: ''
 
-  podAnnotations:
-    prometheus.io/scrape: 'true'
-    prometheus.io/path: /actuator/prometheus
-    prometheus.io/port: '8081'
-
   resources:
     limits:
       memory: "512Mi"
@@ -99,6 +94,10 @@ services:
     image:
       name: "investigation-reporting-service"
       tag: "v1.2.0"
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: /actuator/prometheus
+      prometheus.io/port: '8093'
 
   # ----------------------------------------
   # LDF Data Reporting Service
@@ -170,6 +169,10 @@ services:
     image:
       name: "observation-reporting-service"
       tag: "v1.2.0"
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: /actuator/prometheus
+      prometheus.io/port: '8094'
 
   # ----------------------------------------
   # Organization Reporting Service
@@ -205,6 +208,10 @@ services:
     image:
       name: "organization-reporting-service"
       tag: "v1.2.0"
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: /actuator/prometheus
+      prometheus.io/port: '8092'
 
   # ----------------------------------------
   # Person Reporting Service
@@ -242,6 +249,10 @@ services:
     image:
       name: "person-reporting-service"
       tag: "v1.2.0"
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: /actuator/prometheus
+      prometheus.io/port: '8091'
 
   # ----------------------------------------
   # Post-Processing Reporting Service
@@ -281,3 +292,7 @@ services:
     image:
       name: "post-processing-reporting-service"
       tag: "v1.2.0"
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: /actuator/prometheus
+      prometheus.io/port: '8095'


### PR DESCRIPTION
## Description

Configures prometheus scrapers for RTR java services.

Jira ticket: [CNDE-3125](https://cdc-nbs.atlassian.net/browse/CNDE-3125)


## Creating a new Helm chart?
1. Does the service require an ingress?
    - Kubernetes Ingress resource are PATH based and only handled by modernization-api and dataingestion-service helm charts. 
    - Currently, names of Kubernetes services have to be predictable if an ingress needs to point to them
2. Chart directory structure (specific environment values.yaml files are allowed at the same level as values.yaml)
    ```  
    |── charts
        ├── new-helm-chart
            ├── templates
            |   ├── tests
            |   ├── helpers.tpl
            |   ├── *.yaml
            |   └─ Chart.yaml
            ├── values.yaml
            └─  README.md
    ```    
3. **Do not include secret values anywhere in a Helm chart, take special care when creating values.yaml**
4. values.yaml is annotated to include parameter description and format as appropriate.
    - values.yaml is considered the production/default parameter file and should point to publically available container registries, if the service is publically available.    

## Updating a Helm Chart?
1. Ensure no secrets have been committed.
2. Ensure updates to existing Helm charts follow the guidelines contained in section [Creating a new Helm chart](#creating-a-new-helm-chart).

