### PR TITLE
CNDE-3138: Add/update feature flag to disable processing PHCF datamart

### DIFF
--- a/charts/rtr/templates/deployment.yaml
+++ b/charts/rtr/templates/deployment.yaml
@@ -112,8 +112,8 @@ spec:
                   key: {{ $.Values.global.secrets.kafka.cluster | quote }}
             - name: DA_LOG_PATH
               value: {{- if and (hasKey $service "log") (hasKey $service.log "path") }} {{ $service.log.path | quote }} {{- else }} {{ $.Values.global.log.path | quote }} {{- end }}
-            - name: FF_PHC_DM_ENABLE
-              value: {{- if and (hasKey $service "featureFlag") (hasKey $service.featureFlag "phcDatamartEnable") }} {{ $service.featureFlag.phcDatamartEnable | quote }} {{- else }} "false" {{- end }}
+            - name: FF_PHC_DM_DISABLE
+              value: {{- if and (hasKey $service "featureFlag") (hasKey $service.featureFlag "phcDatamartDisable") }} {{ $service.featureFlag.phcDatamartDisable | quote }} {{- else }} "false" {{- end }}
             - name: FF_ES_ENABLE
               value: {{- if and (hasKey $service "featureFlag") (hasKey $service.featureFlag "elasticSearchEnable") }} {{ $service.featureFlag.elasticSearchEnable | quote }} {{- else }} "false" {{- end }}
             - name: FF_SERVICE_DISABLE

--- a/charts/rtr/values-dts1.yaml
+++ b/charts/rtr/values-dts1.yaml
@@ -77,8 +77,7 @@ services:
       name: ''
       annotations: { }
     featureFlag:
-      phcDatamartEnable: "true"
-      covidDmEnable: "false"
+      phcDatamartDisable: "false"
     log:
       path: /usr/share/investigation-reporting/data
     probes:
@@ -193,6 +192,9 @@ services:
       create: true
       name: ''
       annotations: { }
+    featureFlag:
+      elasticSearchEnable: "true"
+      phcDatamartDisable: "false"
     log:
       path: /usr/share/organization-reporting/data
     probes:
@@ -234,7 +236,7 @@ services:
       annotations: { }
     featureFlag:
       elasticSearchEnable: "true"
-      covidDmEnable: "false"
+      phcDatamartDisable: "false"
     log:
       path: /usr/share/person-reporting/data
     probes:

--- a/charts/rtr/values-dummy.yaml
+++ b/charts/rtr/values-dummy.yaml
@@ -78,7 +78,7 @@ services:
       name: ''
       annotations: { }
     featureFlag:
-      phcDatamartEnable: "true"
+      phcDatamartDisable: "false"
     log:
       path: /usr/share/investigation-reporting/data
     probes:
@@ -185,6 +185,9 @@ services:
       create: true
       name: ''
       annotations: { }
+    featureFlag:
+      elasticSearchEnable: "true"
+      phcDatamartDisable: "false"
     log:
       path: /usr/share/organization-reporting/data
     probes:
@@ -222,6 +225,7 @@ services:
       annotations: { }
     featureFlag:
       elasticSearchEnable: "true"
+      phcDatamartDisable: "false"
     log:
       path: /usr/share/person-reporting/data
     probes:

--- a/charts/rtr/values.yaml
+++ b/charts/rtr/values.yaml
@@ -75,7 +75,7 @@ services:
       name: ''
       annotations: { }
     featureFlag:
-      phcDatamartEnable: "true"
+      phcDatamartDisable: "false"
     log:
       path: /usr/share/investigation-reporting/data
     probes:
@@ -182,6 +182,9 @@ services:
       create: true
       name: ''
       annotations: { }
+    featureFlag:
+      elasticSearchEnable: "true"
+      phcDatamartDisable: "false"
     log:
       path: /usr/share/organization-reporting/data
     probes:
@@ -219,6 +222,7 @@ services:
       annotations: { }
     featureFlag:
       elasticSearchEnable: "true"
+      phcDatamartDisable: "false"
     log:
       path: /usr/share/person-reporting/data
     probes:


### PR DESCRIPTION
## Description

Updates the feature flag to optionally skip processing of PHCF datamart in the RTR pre-processing services.

Jira ticket: [CNDE-3138](https://cdc-nbs.atlassian.net/browse/CNDE-3138)


## Creating a new Helm chart?
1. Does the service require an ingress?
    - Kubernetes Ingress resource are PATH based and only handled by modernization-api and dataingestion-service helm charts. 
    - Currently, names of Kubernetes services have to be predictable if an ingress needs to point to them
2. Chart directory structure (specific environment values.yaml files are allowed at the same level as values.yaml)
    ```  
    |── charts
        ├── new-helm-chart
            ├── templates
            |   ├── tests
            |   ├── helpers.tpl
            |   ├── *.yaml
            |   └─ Chart.yaml
            ├── values.yaml
            └─  README.md
    ```    
3. **Do not include secret values anywhere in a Helm chart, take special care when creating values.yaml**
4. values.yaml is annotated to include parameter description and format as appropriate.
    - values.yaml is considered the production/default parameter file and should point to publically available container registries, if the service is publically available.    

## Updating a Helm Chart?
1. Ensure no secrets have been committed.
2. Ensure updates to existing Helm charts follow the guidelines contained in section [Creating a new Helm chart](#creating-a-new-helm-chart).

