### PR TITLE
Pregnancy Status correction for ECR Ingestion

### DIFF
--- a/charts/dataingestion-service/values-demo.yaml
+++ b/charts/dataingestion-service/values-demo.yaml
@@ -5,7 +5,7 @@ env: "demo"
 image:
   repository: 501715613725.dkr.ecr.us-east-1.amazonaws.com/cdc-nbs-modernization/data-ingestion-service
   pullPolicy: IfNotPresent
-  tag: 7.11.1-SNAPSHOT.944a27b
+  tag: 7.11.1-SNAPSHOT-0002.a9ff6c6
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/dataingestion-service/values-dev.yaml
+++ b/charts/dataingestion-service/values-dev.yaml
@@ -5,7 +5,7 @@ env: "dev"
 image:
   repository: ""
   pullPolicy: IfNotPresent
-  tag: 7.11.1-SNAPSHOT.944a27b
+  tag: 7.11.1-SNAPSHOT-0002.a9ff6c6
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/dataingestion-service/values-feature.yaml
+++ b/charts/dataingestion-service/values-feature.yaml
@@ -5,7 +5,7 @@ env: "feature"
 image:
   repository: ""
   pullPolicy: IfNotPresent
-  tag: 7.11.1-SNAPSHOT.944a27b
+  tag: 7.11.1-SNAPSHOT-0002.a9ff6c6
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/dataingestion-service/values-fts1.yaml
+++ b/charts/dataingestion-service/values-fts1.yaml
@@ -5,7 +5,7 @@ env: "fts1"
 image:
   repository: ""
   pullPolicy: IfNotPresent
-  tag: 7.11.1-SNAPSHOT.944a27b
+  tag: 7.11.1-SNAPSHOT-0002.a9ff6c6
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/dataingestion-service/values-fts2.yaml
+++ b/charts/dataingestion-service/values-fts2.yaml
@@ -5,7 +5,7 @@ env: "fts2"
 image:
   repository: ""
   pullPolicy: IfNotPresent
-  tag: 7.11.1-SNAPSHOT.944a27b
+  tag: 7.11.1-SNAPSHOT-0002.a9ff6c6
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/dataingestion-service/values-int1.yaml
+++ b/charts/dataingestion-service/values-int1.yaml
@@ -5,7 +5,7 @@ env: "int1"
 image:
   repository: ""
   pullPolicy: IfNotPresent
-  tag: 7.11.1-SNAPSHOT.944a27b
+  tag: 7.11.1-SNAPSHOT-0002.a9ff6c6
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/dataingestion-service/values-test2.yaml
+++ b/charts/dataingestion-service/values-test2.yaml
@@ -5,7 +5,7 @@ env: "test"
 image:
   repository: ""
   pullPolicy: IfNotPresent
-  tag: 7.11.1-SNAPSHOT.944a27b
+  tag: 7.11.1-SNAPSHOT-0002.a9ff6c6
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## Description

Updating the new image tag (7.11.1-SNAPSHOT-0002.a9ff6c6) for 7.11.1 release, to include the final ECR Ingestion changes, on the Pregnancy Status in the lookup tables.
PRs - 
- https://github.com/CDCgov/NEDSS-DataIngestion/pull/497
- https://github.com/CDCgov/NEDSS-DataIngestion/pull/499


## Creating a new Helm chart?
1. Does the service require an ingress?
    - Kubernetes Ingress resource are PATH based and only handled by modernization-api and dataingestion-service helm charts. 
    - Currently, names of Kubernetes services have to be predictable if an ingress needs to point to them
2. Chart directory structure (specific environment values.yaml files are allowed at the same level as values.yaml)
    ```  
    |── charts
        ├── new-helm-chart
            ├── templates
            |   ├── tests
            |   ├── helpers.tpl
            |   ├── *.yaml
            |   └─ Chart.yaml
            ├── values.yaml
            └─  README.md
    ```    
3. **Do not include secret values anywhere in a Helm chart, take special care when creating values.yaml**
4. values.yaml is annotated to include parameter description and format as appropriate.
    - values.yaml is considered the production/default parameter file and should point to publically available container registries, if the service is publically available.    

## Updating a Helm Chart?
1. Ensure no secrets have been committed.
2. Ensure updates to existing Helm charts follow the guidelines contained in section [Creating a new Helm chart](#creating-a-new-helm-chart).

