### PR TITLE
CNDE-3125 RTR Prometheus metrics to higher environments

### DIFF
--- a/charts/rtr/values-dummy.yaml
+++ b/charts/rtr/values-dummy.yaml
@@ -97,6 +97,10 @@ services:
     image:
       name: "investigation-reporting-service"
       tag: "v1.1.9"
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: /actuator/prometheus
+      prometheus.io/port: '8093'
 
   # ----------------------------------------
   # LDF Data Reporting Service
@@ -168,6 +172,10 @@ services:
     image:
       name: "observation-reporting-service"
       tag: "v1.1.9"
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: /actuator/prometheus
+      prometheus.io/port: '8094'
 
   # ----------------------------------------
   # Organization Reporting Service
@@ -206,6 +214,10 @@ services:
     image:
       name: "organization-reporting-service"
       tag: "v1.1.9"
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: /actuator/prometheus
+      prometheus.io/port: '8092'
 
   # ----------------------------------------
   # Person Reporting Service
@@ -244,6 +256,10 @@ services:
     image:
       name: "person-reporting-service"
       tag: "v1.1.9"
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: /actuator/prometheus
+      prometheus.io/port: '8091'
 
   # ----------------------------------------
   # Post-Processing Reporting Service
@@ -283,3 +299,7 @@ services:
     image:
       name: "post-processing-reporting-service"
       tag: "v1.1.9"
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: /actuator/prometheus
+      prometheus.io/port: '8095'

--- a/charts/rtr/values.yaml
+++ b/charts/rtr/values.yaml
@@ -94,6 +94,10 @@ services:
     image:
       name: "investigation-reporting-service"
       tag: "v1.2.0"
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: /actuator/prometheus
+      prometheus.io/port: '8093'
 
   # ----------------------------------------
   # LDF Data Reporting Service
@@ -165,6 +169,10 @@ services:
     image:
       name: "observation-reporting-service"
       tag: "v1.2.0"
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: /actuator/prometheus
+      prometheus.io/port: '8094'
 
   # ----------------------------------------
   # Organization Reporting Service
@@ -203,6 +211,10 @@ services:
     image:
       name: "organization-reporting-service"
       tag: "v1.2.0"
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: /actuator/prometheus
+      prometheus.io/port: '8092'
 
   # ----------------------------------------
   # Person Reporting Service
@@ -241,6 +253,10 @@ services:
     image:
       name: "person-reporting-service"
       tag: "v1.2.0"
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: /actuator/prometheus
+      prometheus.io/port: '8091'
 
   # ----------------------------------------
   # Post-Processing Reporting Service
@@ -280,3 +296,7 @@ services:
     image:
       name: "post-processing-reporting-service"
       tag: "v1.2.0"
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: /actuator/prometheus
+      prometheus.io/port: '8095'


### PR DESCRIPTION
## Description

Configures prometheus scrapers for RTR java services - all environments.
Jira ticket: [CNDE-3125](https://cdc-nbs.atlassian.net/browse/CNDE-3125)


## Creating a new Helm chart?
1. Does the service require an ingress?
    - Kubernetes Ingress resource are PATH based and only handled by modernization-api and dataingestion-service helm charts. 
    - Currently, names of Kubernetes services have to be predictable if an ingress needs to point to them
2. Chart directory structure (specific environment values.yaml files are allowed at the same level as values.yaml)
    ```  
    |── charts
        ├── new-helm-chart
            ├── templates
            |   ├── tests
            |   ├── helpers.tpl
            |   ├── *.yaml
            |   └─ Chart.yaml
            ├── values.yaml
            └─  README.md
    ```    
3. **Do not include secret values anywhere in a Helm chart, take special care when creating values.yaml**
4. values.yaml is annotated to include parameter description and format as appropriate.
    - values.yaml is considered the production/default parameter file and should point to publically available container registries, if the service is publically available.    

## Updating a Helm Chart?
1. Ensure no secrets have been committed.
2. Ensure updates to existing Helm charts follow the guidelines contained in section [Creating a new Helm chart](#creating-a-new-helm-chart).

