### PR TITLE
CNDE-3152: Add thread pool feature flag for RTR organization-reporting

### DIFF
--- a/charts/rtr/templates/deployment.yaml
+++ b/charts/rtr/templates/deployment.yaml
@@ -118,6 +118,8 @@ spec:
               value: {{- if and (hasKey $service "featureFlag") (hasKey $service.featureFlag "elasticSearchEnable") }} {{ $service.featureFlag.elasticSearchEnable | quote }} {{- else }} "false" {{- end }}
             - name: FF_SERVICE_DISABLE
               value: {{- if and (hasKey $service "featureFlag") (hasKey $service.featureFlag "serviceDisable") }} {{ $service.featureFlag.serviceDisable | quote }} {{- else }} "false" {{- end }}
+            - name: FF_THREAD_POOL_SIZE
+              value: {{- if and (hasKey $service "featureFlag") (hasKey $service.featureFlag "threadPoolSize") }} {{ $service.featureFlag.threadPoolSize }} {{- else }} 1 {{- end }}
 
       {{- if $service.nodeSelector }}
       nodeSelector:

--- a/charts/rtr/values-dts1.yaml
+++ b/charts/rtr/values-dts1.yaml
@@ -193,8 +193,9 @@ services:
       name: ''
       annotations: { }
     featureFlag:
-      elasticSearchEnable: "true"
+      elasticSearchEnable: "false"
       phcDatamartDisable: "false"
+      threadPoolSize: 1
     log:
       path: /usr/share/organization-reporting/data
     probes:


### PR DESCRIPTION
## Description

Introduce a configurable thread pool size for the RTR Organization pre-processing service.

## Creating a new Helm chart?
1. Does the service require an ingress?
    - Kubernetes Ingress resource are PATH based and only handled by modernization-api and dataingestion-service helm charts. 
    - Currently, names of Kubernetes services have to be predictable if an ingress needs to point to them
2. Chart directory structure (specific environment values.yaml files are allowed at the same level as values.yaml)
    ```  
    |── charts
        ├── new-helm-chart
            ├── templates
            |   ├── tests
            |   ├── helpers.tpl
            |   ├── *.yaml
            |   └─ Chart.yaml
            ├── values.yaml
            └─  README.md
    ```    
3. **Do not include secret values anywhere in a Helm chart, take special care when creating values.yaml**
4. values.yaml is annotated to include parameter description and format as appropriate.
    - values.yaml is considered the production/default parameter file and should point to publically available container registries, if the service is publically available.    

## Updating a Helm Chart?
1. Ensure no secrets have been committed.
2. Ensure updates to existing Helm charts follow the guidelines contained in section [Creating a new Helm chart](#creating-a-new-helm-chart).

