### PR TITLE
CNDE-3156: Add thread pool feature flag for RTR services

### DIFF
--- a/charts/rtr/values-dts1.yaml
+++ b/charts/rtr/values-dts1.yaml
@@ -78,6 +78,7 @@ services:
       annotations: { }
     featureFlag:
       phcDatamartDisable: "false"
+      threadPoolSize: 1
     log:
       path: /usr/share/investigation-reporting/data
     probes:
@@ -154,6 +155,8 @@ services:
       annotations: { }
     log:
       path: /usr/share/observation-reporting/data
+    featureFlag:
+      threadPoolSize: 1
     probes:
       readiness:
         enabled: true
@@ -236,8 +239,9 @@ services:
       name: ''
       annotations: { }
     featureFlag:
-      elasticSearchEnable: "true"
+      elasticSearchEnable: "false"
       phcDatamartDisable: "false"
+      threadPoolSize: 1
     log:
       path: /usr/share/person-reporting/data
     probes:


### PR DESCRIPTION
## Description

Extend a configurable thread pool size for the RTR Investigation, Observation and Person pre-processing services.


## Creating a new Helm chart?
1. Does the service require an ingress?
    - Kubernetes Ingress resource are PATH based and only handled by modernization-api and dataingestion-service helm charts. 
    - Currently, names of Kubernetes services have to be predictable if an ingress needs to point to them
2. Chart directory structure (specific environment values.yaml files are allowed at the same level as values.yaml)
    ```  
    |── charts
        ├── new-helm-chart
            ├── templates
            |   ├── tests
            |   ├── helpers.tpl
            |   ├── *.yaml
            |   └─ Chart.yaml
            ├── values.yaml
            └─  README.md
    ```    
3. **Do not include secret values anywhere in a Helm chart, take special care when creating values.yaml**
4. values.yaml is annotated to include parameter description and format as appropriate.
    - values.yaml is considered the production/default parameter file and should point to publically available container registries, if the service is publically available.    

## Updating a Helm Chart?
1. Ensure no secrets have been committed.
2. Ensure updates to existing Helm charts follow the guidelines contained in section [Creating a new Helm chart](#creating-a-new-helm-chart).

