### PR TITLE
add OTEL log collector values for NBS  environments

### DIFF
--- a/charts/splunk-otel-collector/README.md
+++ b/charts/splunk-otel-collector/README.md
@@ -155,10 +155,8 @@ kubectl -n observability logs -l app=splunk-otel-collector --tail=30
 # Check S3 for recent logs
 aws s3 ls s3://<BUCKET_NAME>/otel-logs/ --recursive --region <REGION> | tail -5
 
-# Effective collector config (port-forward method)
-kubectl -n observability port-forward <agent-pod> 55554:55554
-# Then in separate terminal:
-curl http://localhost:55554/debug/configz/effective
+# View effective collector config
+kubectl -n observability exec <agent-pod> -- cat /conf/relay.yaml
 ```
 
 ## Post-Deployment Checklist

--- a/charts/splunk-otel-collector/README.md
+++ b/charts/splunk-otel-collector/README.md
@@ -5,6 +5,11 @@ OTEL Log Collector values for NBS environments — replaces FluentBit.
 ## Overview
 This directory contains the Helm values file for deploying the upstream [Splunk OpenTelemetry Collector for Kubernetes](https://github.com/signalfx/splunk-otel-collector-chart) chart to NBS clusters. No wrapper chart — just a values file passed directly to the upstream chart.
 
+Primary use case: ship container logs from NBS EKS/AKS clusters to a durable store (S3 or Azure Blob) for crash investigation and debugging. Splunk HEC is available as an additional destination but is not required
+
+### What role does Splunk play?
+Splunk is not required to use this chart. Splunk HEC is only applicable in environments where a HEC token has been provisioned. The upstream chart requires `<splunkPlatform.token>` to pass schema validation, so a `<"placeholder">` value is set in values.yaml. No data is sent to Splunk with a placeholder token and `<logsEnabled: false>`.
+
 ### Log Destinations
 
 | Destination | Status | How to Enable |
@@ -30,6 +35,7 @@ charts/splunk-otel-collector/
 - For Splunk: a HEC token
 
 ## Deploy to EKS
+ Before deploying, complete the S3 Setup for EKS section below to create the S3 bucket, IAM policy, and IRSA role. The <IRSA_ROLE_NAME> in the deploy command comes from Step 3 of that section.
 
 ```bash
 # Add upstream repo
@@ -39,7 +45,7 @@ helm repo update
 # Update placeholders in values.yaml:
 #   clusterName, environment, s3_bucket, region
 
-# Deploy
+# Deploy (replace <ACCOUNT_ID> and <IRSA_ROLE_NAME> with values from S3 Setup Step 3)
 helm install splunk-otel-collector \
   splunk-otel-collector-chart/splunk-otel-collector \
   -f values.yaml \
@@ -91,6 +97,7 @@ aws s3 mb s3://<BUCKET_NAME> --region <REGION>
 ```
 
 ### Step 3: Create IRSA role
+IRSA (IAM Roles for Service Accounts) lets the OTEL collector pods assume an IAM role without static credentials. Each EKS cluster requires its own IRSA role because each cluster has a unique OIDC provider.
 
 1. Get the cluster OIDC provider:
    ```bash
@@ -100,6 +107,8 @@ aws s3 mb s3://<BUCKET_NAME> --region <REGION>
 2. Create an IAM role with Web Identity trust policy using the OIDC URL
 3. Set the trust condition to: `system:serviceaccount:observability:splunk-otel-collector`
 4. Attach the S3 write policy to the role
+
+The role name you create here (e.g., OtelS3Role-<cluster>) is the <IRSA_ROLE_NAME> used in the Deploy to EKS command.
 
 ### Step 4: Deploy with IRSA
 

--- a/charts/splunk-otel-collector/README.md
+++ b/charts/splunk-otel-collector/README.md
@@ -162,7 +162,7 @@ kubectl get pods -n observability -l app=splunk-otel-collector
 kubectl -n observability logs -l app=splunk-otel-collector --tail=30
 
 # Check S3 for recent logs
-aws s3 ls s3://<BUCKET_NAME>/otel-logs/ --recursive --region <REGION> | tail -5
+aws s3 ls s3://<BUCKET_NAME>/<CLUSTER_NAME>/ --recursive --region <REGION> | tail -5
 
 # View effective collector config
 kubectl -n observability exec <agent-pod> -- cat /conf/relay.yaml

--- a/charts/splunk-otel-collector/README.md
+++ b/charts/splunk-otel-collector/README.md
@@ -1,0 +1,189 @@
+# splunk-otel-collector
+
+OTEL Log Collector values for NBS environments — replaces FluentBit.
+
+## Overview
+This directory contains the Helm values file for deploying the upstream [Splunk OpenTelemetry Collector for Kubernetes](https://github.com/signalfx/splunk-otel-collector-chart) chart to NBS clusters. No wrapper chart — just a values file passed directly to the upstream chart.
+
+### Log Destinations
+
+| Destination | Status | How to Enable |
+|---|---|---|
+| **AWS S3** | Configured | Update `<S3_BUCKET_NAME>` and `<AWS_REGION>` in values.yaml |
+| **Azure Blob** | Placeholder | Uncomment `azureblob` exporter and supply connection string |
+| **Splunk HEC** | Placeholder | Replace `token` with real HEC token |
+
+## Directory Structure
+
+```
+charts/splunk-otel-collector/
+├── values.yaml     # All config — S3, Azure Blob, Splunk, multiline, excludePaths
+└── README.md
+```
+
+## Prerequisites
+
+- Helm 3.12+
+- `kubectl` access to the target cluster
+- For S3: an existing S3 bucket + IAM permissions (see [S3 Setup](#s3-setup-for-eks))
+- For Azure Blob: an existing Storage Account + container + connection string
+- For Splunk: a HEC token
+
+## Deploy to EKS
+
+```bash
+# Add upstream repo
+helm repo add splunk-otel-collector-chart https://signalfx.github.io/splunk-otel-collector-chart
+helm repo update
+
+# Update placeholders in values.yaml:
+#   clusterName, environment, s3_bucket, region
+
+# Deploy
+helm install splunk-otel-collector \
+  splunk-otel-collector-chart/splunk-otel-collector \
+  -f values.yaml \
+  --set "serviceAccount.annotations.eks\.amazonaws\.com/role-arn=arn:aws:iam::<ACCOUNT_ID>:role/<IRSA_ROLE_NAME>" \
+  -n observability --create-namespace --skip-schema-validation
+```
+
+## Deploy to AKS
+
+1. Update `clusterName` and `environment` in values.yaml
+2. Uncomment the `azureblob` exporter and add it to the pipeline exporters
+3. Replace EKS `excludePaths` with AKS ones (see comments in values.yaml)
+4. Comment out the `awss3` exporter if not needed
+
+```bash
+helm install splunk-otel-collector \
+  splunk-otel-collector-chart/splunk-otel-collector \
+  -f values.yaml \
+  --set "agent.config.exporters.azureblob.connection_string=<CONNECTION_STRING>" \
+  -n observability --create-namespace --skip-schema-validation
+```
+
+## S3 Setup for EKS
+
+The OTEL collector **does NOT create S3 buckets**. Create the bucket and IAM permissions before deploying.
+
+### Step 1: Create S3 bucket
+
+```bash
+aws s3 mb s3://<BUCKET_NAME> --region <REGION>
+```
+
+### Step 2: Create IAM policy
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:PutObject", "s3:GetBucketLocation"],
+      "Resource": [
+        "arn:aws:s3:::<BUCKET_NAME>",
+        "arn:aws:s3:::<BUCKET_NAME>/*"
+      ]
+    }
+  ]
+}
+```
+
+### Step 3: Create IRSA role
+
+1. Get the cluster OIDC provider:
+   ```bash
+   aws eks describe-cluster --name <CLUSTER_NAME> --region <REGION> \
+     --query "cluster.identity.oidc.issuer" --output text
+   ```
+2. Create an IAM role with Web Identity trust policy using the OIDC URL
+3. Set the trust condition to: `system:serviceaccount:observability:splunk-otel-collector`
+4. Attach the S3 write policy to the role
+
+### Step 4: Deploy with IRSA
+
+```bash
+helm install splunk-otel-collector \
+  splunk-otel-collector-chart/splunk-otel-collector \
+  -f values.yaml \
+  --set "serviceAccount.annotations.eks\.amazonaws\.com/role-arn=arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>" \
+  -n observability --create-namespace --skip-schema-validation
+```
+
+### Step 5: Verify logs in S3
+
+```bash
+aws s3 ls s3://<BUCKET_NAME>/otel-logs/ --recursive --region <REGION> | head -20
+```
+
+## Will this disrupt my cluster?
+
+**No.** The OTEL collector is purely additive:
+
+- Deploys as a new DaemonSet in its own `observability` namespace
+- Reads from `/var/log/pods/` on the node filesystem (read-only)
+- Does NOT modify, restart, or interfere with any existing pods
+- Resource requests are modest (100m CPU / 256Mi RAM per node)
+
+To remove: `helm uninstall splunk-otel-collector -n observability`
+
+## How It Works
+
+The collector deploys as a DaemonSet — one agent per node. Each agent tails `/var/log/pods/` on its node and ships logs to the configured exporters.
+
+### Crash Log Durability
+
+When a pod crashes:
+1. Kubernetes preserves the crash logs on the node filesystem
+2. The OTEL agent (separate pod) reads them and ships to S3/Blob/Splunk
+3. The persistent queue buffers unsent logs to disk if the agent itself restarts
+
+### Multiline Stack Traces
+
+Java stack traces from NBS pods are combined into single log records. Update `namespaceName` in the multiline config to match where your NBS pods are deployed.
+
+## Validation
+
+```bash
+# Check agent pods
+kubectl get pods -n observability -l app=splunk-otel-collector
+
+# Agent logs
+kubectl -n observability logs -l app=splunk-otel-collector --tail=30
+
+# Check S3 for recent logs
+aws s3 ls s3://<BUCKET_NAME>/otel-logs/ --recursive --region <REGION> | tail -5
+
+# Effective collector config (port-forward method)
+kubectl -n observability port-forward <agent-pod> 55554:55554
+# Then in separate terminal:
+curl http://localhost:55554/debug/configz/effective
+```
+
+## Post-Deployment Checklist
+
+- [ ] OTEL agent pods running on all nodes
+- [ ] Logs flowing to configured destination (S3 / Blob / Splunk)
+- [ ] Simulate a pod crash → confirm logs persist across agent restart
+
+## Troubleshooting
+
+**Agent pods won't start?**
+The upstream chart requires `splunkPlatform.token` to be set. Use `"placeholder"` if Splunk isn't active.
+
+**No logs in S3?**
+1. Check agent logs: `kubectl -n observability logs <agent-pod> | grep -i s3`
+2. Verify IAM: does the pod's ServiceAccount have `s3:PutObject`?
+3. Verify bucket exists: `aws s3 ls s3://<bucket-name>/`
+4. Check IRSA: `kubectl get sa -n observability -o yaml` — verify the role ARN annotation is present.
+
+**No logs in Azure Blob?**
+1. Check agent logs: `kubectl -n observability logs <agent-pod> | grep -i azure`
+2. Verify connection string is correct and container exist
+
+**Stack traces split across multiple log entries?**
+Verify `namespaceName` in multiline config matches where your pods run.
+
+**High memory on agent pods?**
+Increase `agent.resources.limits.memory` or reduce `sendingQueue.queueSize`.

--- a/charts/splunk-otel-collector/values.yaml
+++ b/charts/splunk-otel-collector/values.yaml
@@ -11,9 +11,9 @@
 #     -n observability --create-namespace
 #
 # This file configures three log export destinations:
-#   1. AWS S3        — update bucket name and region below
-#   2. Azure Blob    — uncomment and update connection_string to enable
-#   3. Splunk HEC    — update token to enable for environments where a HEC token is available
+#   1. Splunk HEC    — update token to enable for environments where a HEC token is available
+#   2. AWS S3        — update bucket name and region below
+#   3. Azure Blob    — uncomment and update connection_string to enable
 #
 # REQUIRED: update clusterName per environment before deploying.
 # =============================================================================

--- a/charts/splunk-otel-collector/values.yaml
+++ b/charts/splunk-otel-collector/values.yaml
@@ -80,7 +80,7 @@ agent:
           region: "<AWS_REGION>"
           s3_bucket: "<S3_BUCKET_NAME>"
           s3_prefix: "otel-logs"
-          s3_partition: "minute"
+          s3_partition_format: "year=%Y/month=%m/day=%d/hour=%H/minute=%M"
         marshaler: otlp_json
       # Uncomment to enable Azure Blob export:
       # azureblob:

--- a/charts/splunk-otel-collector/values.yaml
+++ b/charts/splunk-otel-collector/values.yaml
@@ -1,0 +1,161 @@
+# =============================================================================
+# Splunk OpenTelemetry Collector — NBS Values File
+# =============================================================================
+# Deploy directly with the upstream chart:
+#
+#   helm repo add splunk-otel-collector-chart https://signalfx.github.io/splunk-otel-collector-chart
+#   helm repo update
+#   helm install splunk-otel-collector \
+#     splunk-otel-collector-chart/splunk-otel-collector \
+#     -f values.yaml \
+#     -n observability --create-namespace
+#
+# This file configures three log export destinations:
+#   1. AWS S3        — update bucket name and region below
+#   2. Azure Blob    — uncomment and update connection_string to enable
+#   3. Splunk HEC    — update token to enable
+#
+# REQUIRED: update clusterName per environment before deploying.
+# =============================================================================
+
+# -- Cluster name. Update per environment.
+clusterName: "<CLUSTER_NAME>"
+
+# -- Environment tag for downstream log correlation
+environment: "<ENVIRONMENT>"
+
+# =============================================================================
+# EXPORTER 1: Splunk Platform (HEC) — PLACEHOLDER
+# =============================================================================
+# To enable, replace token with a real HEC token and set logsEnabled to true.
+splunkPlatform:
+  endpoint: "https://http-inputs.cdc.splunkcloudgc.com:443/services/collector/event"
+  token: "placeholder"
+  index: "kubernetes_logs"
+  metricsIndex: "metrics_test"
+  logsEnabled: true
+  metricsEnabled: false
+  retryOnFailure:
+    enabled: true
+    initialInterval: 5s
+    maxInterval: 30s
+    maxElapsedTime: 300s
+  sendingQueue:
+    enabled: true
+    numConsumers: 10
+    queueSize: 5000
+    persistentQueue:
+      enabled: true
+      storagePath: "/var/addon/splunk/exporter_queue"
+
+# =============================================================================
+# Agent DaemonSet
+# =============================================================================
+agent:
+  hostNetwork: false
+  resources:
+    limits:
+      cpu: 500m
+      memory: 1Gi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+  config:
+    # =========================================================================
+    # EXPORTER 2: AWS S3
+    # =========================================================================
+    # Writes OTLP JSON log batches to an S3 bucket, partitioned by minute.
+    # The bucket must already exist. Authentication via IRSA or node
+    # instance profile.
+    #
+    # =========================================================================
+    # EXPORTER 3: Azure Blob Storage — PLACEHOLDER
+    # =========================================================================
+    # To enable for AKS clusters, uncomment the azureblob exporter below
+    # and add it to the logs pipeline exporters list.
+    #
+    exporters:
+      awss3:
+        s3uploader:
+          region: "<AWS_REGION>"
+          s3_bucket: "<S3_BUCKET_NAME>"
+          s3_prefix: "otel-logs"
+          s3_partition: "minute"
+        marshaler: otlp_json
+      # Uncomment to enable Azure Blob export:
+      # azureblob:
+      #   connection_string: "<AZURE_BLOB_CONNECTION_STRING>"
+      #   container: "<AZURE_BLOB_CONTAINER>"
+      #   blob_prefix: "otel-logs"
+      #   marshaler: otlp_json
+    service:
+      pipelines:
+        logs:
+          exporters:
+            - awss3
+            # - azureblob  # Uncomment when Azure Blob is enabled
+
+# =============================================================================
+# Log Collection
+# =============================================================================
+logsCollection:
+  containers:
+    # -------------------------------------------------------------------------
+    # Exclude Paths
+    # -------------------------------------------------------------------------
+    # EKS-specific system pod exclusions. For AKS, replace with:
+    #   - '/var/log/pods/cattle-fleet-system_fleet-agent-*/fleet-agent/*.log'
+    #   - '/var/log/pods/calico-system_calico-node-*/flexvol-driver/*.log'
+    #   - '/var/log/pods/kube-system_ama-metrics-operator-targets-*/targetallocator/*.log'
+    #   - '/var/log/pods/kube-system_cloud-node-manager-*/*.log'
+    #   - '/var/log/pods/kube-system_csi-azuredisk-node-*/*.log'
+    excludePaths:
+      - '/var/log/pods/kube-system_coredns-*/coredns/*.log'
+      - '/var/log/pods/kube-system_kube-proxy-*/*.log'
+      - '/var/log/pods/kube-system_aws-node-*/*.log'
+      - '/var/log/pods/kube-system_ebs-csi-node-*/*.log'
+      - '/var/log/pods/kube-system_efs-csi-node-*/*.log'
+      - '/var/log/pods/amazon-cloudwatch_*/*.log'
+      - '/var/log/pods/observability_*splunk-otel-collector*/*.log'
+    # -------------------------------------------------------------------------
+    # Multiline Log Handling
+    # -------------------------------------------------------------------------
+    # Combines Java stack traces into single log entries.
+    # Update namespaceName to match the namespace where NBS pods are deployed.
+    multilineConfigs:
+      # NBS7 Java microservices (Spring Boot stack traces)
+      - namespaceName:
+          value: 'default'
+        podName:
+          value: '.*'
+          useRegexp: true
+        firstEntryRegex: '^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}'
+        combineWith: '\n'
+      # NBS6 WildFly — uncomment and adjust namespaceName when NBS6 pods are deployed
+      # - namespaceName:
+      #     value: 'default'
+      #   podName:
+      #     value: '.*'
+      #     useRegexp: true
+      #   firstEntryRegex: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}'
+      #   combineWith: '\n'
+      # Azure CSI driver multiline — uncomment for AKS clusters
+      # - namespaceName:
+      #     value: kube-system
+      #   podName:
+      #     value: 'csi-azurefile-node-.*'
+      #     useRegexp: true
+      #   containerName:
+      #     value: azurefile
+      #   firstEntryRegex: '[IE]\\d+\\s\\d+:\\d+:\\d+\\.\\d+'
+      #   combineWith: ''
+
+# =============================================================================
+# Cluster Receiver
+# =============================================================================
+clusterReceiver:
+  enabled: true
+  resources:
+    limits:
+      cpu: 200m
+      memory: 512Mi

--- a/charts/splunk-otel-collector/values.yaml
+++ b/charts/splunk-otel-collector/values.yaml
@@ -13,7 +13,7 @@
 # This file configures three log export destinations:
 #   1. AWS S3        — update bucket name and region below
 #   2. Azure Blob    — uncomment and update connection_string to enable
-#   3. Splunk HEC    — update token to enable
+#   3. Splunk HEC    — update token to enable for environments where a HEC token is available
 #
 # REQUIRED: update clusterName per environment before deploying.
 # =============================================================================
@@ -29,11 +29,11 @@ environment: "<ENVIRONMENT>"
 # =============================================================================
 # To enable, replace token with a real HEC token and set logsEnabled to true.
 splunkPlatform:
-  endpoint: "https://http-inputs.cdc.splunkcloudgc.com:443/services/collector/event"
+  endpoint: "https://<SPLUNK_HEC_ENDPOINT>"
   token: "placeholder"
   index: "kubernetes_logs"
   metricsIndex: "metrics_test"
-  logsEnabled: true
+  logsEnabled: false
   metricsEnabled: false
   retryOnFailure:
     enabled: true
@@ -68,6 +68,11 @@ agent:
     # The bucket must already exist. Authentication via IRSA or node
     # instance profile.
     #
+    # Partition format controls how logs are organized in S3:
+    #   Daily (default):  year=2026/month=03/day=31/
+    #   Hourly:           year=%Y/month=%m/day=%d/hour=%H
+    #   Per-minute:       year=%Y/month=%m/day=%d/hour=%H/minute=%M
+    #
     # =========================================================================
     # EXPORTER 3: Azure Blob Storage — PLACEHOLDER
     # =========================================================================
@@ -80,7 +85,7 @@ agent:
           region: "<AWS_REGION>"
           s3_bucket: "<S3_BUCKET_NAME>"
           s3_prefix: "otel-logs"
-          s3_partition_format: "year=%Y/month=%m/day=%d/hour=%H/minute=%M"
+          s3_partition_format: "year=%Y/month=%m/day=%d"
         marshaler: otlp_json
       # Uncomment to enable Azure Blob export:
       # azureblob:

--- a/charts/splunk-otel-collector/values.yaml
+++ b/charts/splunk-otel-collector/values.yaml
@@ -33,7 +33,7 @@ splunkPlatform:
   token: "placeholder"
   index: "kubernetes_logs"
   metricsIndex: "metrics_test"
-  logsEnabled: false
+  logsEnabled: true
   metricsEnabled: false
   retryOnFailure:
     enabled: true
@@ -84,7 +84,7 @@ agent:
         s3uploader:
           region: "<AWS_REGION>"
           s3_bucket: "<S3_BUCKET_NAME>"
-          s3_prefix: "otel-logs"
+          s3_prefix: "<CLUSTER_NAME>"
           s3_partition_format: "year=%Y/month=%m/day=%d"
         marshaler: otlp_json
       # Uncomment to enable Azure Blob export:


### PR DESCRIPTION
## Description

Adds a Helm values file for deploying the [Splunk OpenTelemetry Collector](https://github.com/signalfx/splunk-otel-collector-chart) to NBS clusters. This replaces FluentBit for durable container log collection.


## What this does
- Deploys an OTEL Collector DaemonSet that tails container logs from every node
- Ships logs to configurable destinations: AWS S3 (active), Azure Blob (placeholder), Splunk HEC (placeholder)
- Multiline recombination for Java stack traces so crash logs ship as single records
- Persistent queue ensures logs survive pod restarts and environment shutdowns

**Validated on:** Skylight internal dev environment — 4 agent pods running 7+ days, zero restarts, logs confirmed in S3 partitioned by year/month/day.


