### PR TITLE
Fix the Case Notification Helm charts DEV-522

### DIFF
--- a/charts/case-notification-service/templates/deployment.yaml
+++ b/charts/case-notification-service/templates/deployment.yaml
@@ -58,7 +58,5 @@ spec:
               value: {{ .Values.api.clientId}}
             - name: NND_DE_SECRET
               value: {{ .Values.api.secret}}
-            - name: NND_DE_URL
-              value: {{ .Values.api.host}}
-            - name: SPRING_PROFILES_ACTIVE
-              value: "{{ .Values.springBootProfile}}"
+            # - name: SPRING_PROFILES_ACTIVE
+            #   value: "{{ .Values.springBootProfile}}"

--- a/charts/case-notification-service/templates/deployment.yaml
+++ b/charts/case-notification-service/templates/deployment.yaml
@@ -50,8 +50,6 @@ spec:
               value: {{ .Values.ingressHost }}
             - name: KAFKA_BOOTSTRAP_SERVER
               value: {{ .Values.kafka.cluster }}
-            - name: NND_DE_URL
-              value: {{ .Values.api.host}}
             - name: SERVICE_TZ
               value: {{ .Values.timezone }}
             - name: NND_DE_CLIENT_ID

--- a/charts/case-notification-service/values.yaml
+++ b/charts/case-notification-service/values.yaml
@@ -1,8 +1,7 @@
 replicaCount: 1
 
-env: "prod"
-
-authUri: ""
+# More info at: https://cdcgov.github.io/NEDSS-SystemAdminGuide/docs/deploy-nbs7/microservices-deployment/case-notification.html#keycloak-configuration
+authUri: "http://keycloak.default.svc.cluster.local/auth/realms/NBS"
 
 image:
   repository: "quay.io/us-cdcgov/cdc-nbs-modernization/nnd-case-notification-service/case-notification-service"
@@ -10,6 +9,7 @@ image:
   tag: "v1.0.3"
 
 imagePullSecrets: []
+
 nameOverride: ""
 fullnameOverride: ""
 
@@ -32,34 +32,28 @@ service:
   port: 8093
   httpsPort: 443
 
-
-resources: {}
-
 autoscaling:
   enabled: false
   minReplicas: 1
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
+  #targetMemoryUtilizationPercentage: 80
 
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
-
-ingressHost: ""
+ingressHost: "data.EXAMPLE_DOMAIN"
 
 kafka:
-  cluster: ""
+  cluster: "EXAMPLE_MSK_KAFKA_ENDPOINT"
 
-# dbserver is passed in as an environment variable. It is just the database endpoint
+# dbserver is just the database endpoint/hostname - not with the port number.
 jdbc:
-  dbserver: ""
-  username: ""
-  password: ""
+  dbserver: "EXAMPLE_DB_ENDPOINT"
+  username: "EXAMPLE_ODSE_DB_USER"
+  password: "EXAMPLE_ODSE_DB_USER_PASSWORD"
 
 timezone: "UTC"
+
 api:
-  host: ""
-  clientId: ""
-  secret: ""
+  host: "https://<data.EXAMPLE_DOMAIN>/hl7-parser"
+  # The following two values are specified in Keycloak, and are needed by the XML HL7 Parser library (which is part of this case-notification-service).
+  clientId: "xml-hl7-parser-keycloak-client"
+  secret: "EXAMPLE_XML-HL7-Parser_CLIENT_SECRET"

--- a/charts/case-notification-service/values.yaml
+++ b/charts/case-notification-service/values.yaml
@@ -53,7 +53,6 @@ jdbc:
 timezone: "UTC"
 
 api:
-  host: "https://<data.EXAMPLE_DOMAIN>/hl7-parser"
   # The following two values are specified in Keycloak, and are needed by the XML HL7 Parser library (which is part of this case-notification-service).
   clientId: "xml-hl7-parser-keycloak-client"
   secret: "EXAMPLE_XML-HL7-Parser_CLIENT_SECRET"

--- a/charts/debezium-case-notifications/templates/NOTES.txt
+++ b/charts/debezium-case-notifications/templates/NOTES.txt
@@ -1,5 +1,5 @@
 1. Get the application URL by running these commands:
-{{- if .Values.ui.ingress.enabled }}
+{{- if and .Values.ui.ingress.enabled .Values.ui.enabled }}
   http://{{ .Values.ui.ingress.host }}
 {{- else if contains "NodePort" .Values.connect.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "debezium.fullname" . }})

--- a/charts/debezium-case-notifications/templates/_helpers.tpl
+++ b/charts/debezium-case-notifications/templates/_helpers.tpl
@@ -65,14 +65,3 @@ app.kubernetes.io/name: {{ include "debezium.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/app: ui
 {{- end }}
-
-{{/*
-Create the name of the service account to use
-*/}}
-{{- define "debezium.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "debezium.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
-{{- end }}

--- a/charts/debezium-case-notifications/values.yaml
+++ b/charts/debezium-case-notifications/values.yaml
@@ -1,8 +1,16 @@
 nameOverride: "case-notification"
 fullnameOverride: ""
+
 log_level: INFO
+
 connect:
+  #affinity
+  #nodeSelector
+  #podAnnotations
+  #tolerations
+
   replicaCount: 1
+
   imagePullSecrets: [ ]
 
   image:
@@ -16,9 +24,6 @@ connect:
     protocol: TCP
     name: http
 
-  ingress:
-    enabled: false
-
   autoscaling:
     enabled: false
 
@@ -27,8 +32,8 @@ connect:
       cpu: 1000m
       memory: 1Gi
     requests:
-      cpu: 500m
-      memory: 500m
+      cpu: 500m 
+      memory: 500Mi
 
   properties:
     group_id: "debezium-odse-case-notifications-connector-v061725-2"
@@ -39,8 +44,6 @@ connect:
     sql_server_agent_override: false
     sql_server_agent_status: ""
     bootstrap_server: "EXAMPLE_MSK_KAFKA_ENDPOINT"
-
-  # dbserver: "EXAMPLE_DB_ENDPOINT"
 
   connector_enable:
     nbs_case_notification: "enabled"
@@ -124,7 +127,14 @@ connect:
 
 ui:
   enabled: false
+
+  #affinity
+  #nodeSelector
+  #podAnnotations
+  #tolerations
+
   replicaCount: 1
+
   imagePullSecrets: [ ]
 
   image:
@@ -151,7 +161,7 @@ ui:
       cpu: 500m
       memory: 1Gi
     requests:
-      cpu: 500m
+      cpu: 500m 
       memory: 1Gi
 
   env:
@@ -159,4 +169,3 @@ ui:
       value: "http://debezium-case-notifications-connect:8083"
     - name: TZ
       value: "UTC"
-


### PR DESCRIPTION
fyi on our dev72 environment I have run `helm install` for the changes from this PR:
```
jolson@Joshs-Skylight-MBP in ~ 
❯ kubectl get pods | grep case-notification
case-notification-service-dd75cccc6-t49rs                         2/2     Running     0               25m
debezium-case-notification-service-connect-connect-69c4c57gpww6   2/2     Running     0               119m
```

I noticed the Description of the https://github.com/CDCgov/NEDSS-NNDSS-Case-Notifications/pull/113 PR says:

- "Removes `xml-hl7-parser-service` and creates `xml-hl7-parser` library. Updates `case-notification-service` to use the library rather than the API service for XML->HL7 transformations."