### PR TITLE
Serban/downgrade 7.12.0 nnd

### DIFF
--- a/charts/nnd-service/values.yaml
+++ b/charts/nnd-service/values.yaml
@@ -4,7 +4,7 @@ env: "prod"
 
 image:
   #repository: "public.ecr.aws/o1z7u2g7/cdc-nbs-modernization/nnd-service"
-  repository: "quay.io/us-cdcgov/cdc-nbs-modernization/nnd-service"
+  repository: "quay.io/us-cdcgov/cdc-nbs-modernization/nnd-data-exchange-service"
   pullPolicy: IfNotPresent
   tag: "v1.1.3"
 

--- a/charts/nnd-service/values.yaml
+++ b/charts/nnd-service/values.yaml
@@ -6,7 +6,7 @@ image:
   #repository: "public.ecr.aws/o1z7u2g7/cdc-nbs-modernization/nnd-service"
   repository: "quay.io/us-cdcgov/cdc-nbs-modernization/nnd-service"
   pullPolicy: IfNotPresent
-  tag: "v1.1.5"
+  tag: "v1.1.3"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## Description

Downgrades nnd-service to version v1.1.3. Note this version use a different repository for the container that was updated as a part of the v7.11.0 release.


## Creating a new Helm chart?
1. Does the service require an ingress?
    - Kubernetes Ingress resource are PATH based and only handled by modernization-api and dataingestion-service helm charts. 
    - Currently, names of Kubernetes services have to be predictable if an ingress needs to point to them
2. Chart directory structure (specific environment values.yaml files are allowed at the same level as values.yaml)
    ```  
    |── charts
        ├── new-helm-chart
            ├── templates
            |   ├── tests
            |   ├── helpers.tpl
            |   ├── *.yaml
            |   └─ Chart.yaml
            ├── values.yaml
            └─  README.md
    ```    
3. **Do not include secret values anywhere in a Helm chart, take special care when creating values.yaml**
4. values.yaml is annotated to include parameter description and format as appropriate.
    - values.yaml is considered the production/default parameter file and should point to publically available container registries, if the service is publically available.    

## Updating a Helm Chart?
1. Ensure no secrets have been committed.
2. Ensure updates to existing Helm charts follow the guidelines contained in section [Creating a new Helm chart](#creating-a-new-helm-chart).

