### PR TITLE
Fix the dataingestion-service Helm charts DEV-525

### DIFF
--- a/charts/dataingestion-service/README.md
+++ b/charts/dataingestion-service/README.md
@@ -1,36 +1,29 @@
 # Overview
-This helm chart data-ingestion enables NBS to seamlessly ingest HL7 data from labs and other entities into the NBS system.
+
+This Helm chart is for `dataingestion-service`, which enables NBS to seamlessly ingest HL7 data from labs and other entities into the NBS system.
 
 # Requirements
-Kubernetes >=1.20.0-0
 
+See https://cdcgov.github.io/NEDSS-SystemAdminGuide/docs/deploy-nbs7/quickstart.html#environment-requirements and https://cdcgov.github.io/NEDSS-SystemAdminGuide/docs/deploy-nbs7/prerequisites.html#required-tools and https://cdcgov.github.io/NEDSS-SystemAdminGuide/docs/deploy-nbs7/prerequisites.html#software-versions .
 
 # Install Chart
-### Note: Please ensure image.repository, image.tag, ingressHost, kafka cluster, efsid, jdbc and sftp are populated before running this helm chart.  Please see the values section below for more details.  
 
-Make sure the helm chart is on your local machine and run the following commands:
+See https://cdcgov.github.io/NEDSS-SystemAdminGuide/docs/deploy-nbs7/data-ingestion/data-ingestion.html .
 
-**Mac OS/Linux**
+# Uninstall Chart
 
-helm install dataingestion-service -f ./dataingestion-service/values.yaml dataingestion-service
+To uninstall this Helm chart, run the following command:
 
-**Windows**
-
-helm install dataingestion-service -f .\dataingestion-service\values.yaml dataingestion-service
-
-# Remove Chart
-To uninstall helm chart, run the following command:
-
-helm uninstall dataingestion-service
+`helm uninstall dataingestion-service`
 
 # Values
+
 Values for dataingestion-service charts.
 
-| Key | Type | Default | Description | Required |
-| -------------- | -------------- | -------------- | -------------- | -------------- |
+| Key                 | Type   | Default                                                                        | Description                                                                                                                        | Required |
+| --------------      | -------------- | -------------- | -------------- | -------------- |
 | replicaCount        | int    | 1                                                                              | Number of Pods maintained. Defaulted to 1                                                                                          | N            |
-| env                 | string | "prod"                                                                         | Environment information. This can be any environment string                                                                        | N            |
-| image               | string |                                                                                | Data-ingestion container image. Needs to point to the latest image from the public repository                               | N            |
+| image               | string |                                                                                | Data-ingestion container image. Needs to point to the latest image from the public repository                                      | N            |
 | tag                 | string |                                                                                | Point to release tag that needs to be installed with NBS. This is required                                                         | N            |
 | nameOverride        | string | ""                                                                             | replaces name of chart on install. Not required.                                                                                   | N            |
 | fullnameOverride    | string | ""                                                                             | replaces full generated name on install. Not required.                                                                             | N            |
@@ -39,14 +32,14 @@ Values for dataingestion-service charts.
 | podSecurityContext  | object | {}                                                                             | Defines privilege and access control. Not Required                                                                                 | N            |
 | securityContext     | object | {}                                                                             | Defines privilege and access control. Not Required                                                                                 | N            |
 | service             | object | Defaults to clusterIP with port 8080, httpsport to 443 and gatewayPort to 8000 | Configures service ClusterIP with some ports                                                                                       | N            |
-| ingress             | object | true with tls information                                                      | Creation of NGINX Ingress resource                                                                                                 | Y            |
-| resources           | object | limits memory to 4GB                                                           | Enable default resources                                                                                                           | N            |
+| ingress             | object | true                                                                           | Creation of NGINX Ingress resource                                                                                                 | Y            |
+| resources           | object |                                                                                | Server resource requests and limits                                                                                                | N            |
 | autoscaling         | object | false                                                                          | Kubernetes POD autoscaler                                                                                                          | N            |
 | nodeSelector        | object | {}                                                                             | Node assignment to Pod                                                                                                             | N            |
 | tolerations         | list   | []                                                                             | Set Pod tolerations                                                                                                                | N            |
 | affinity            | object | {}                                                                             | Define needed contraints                                                                                                           | N            |
 | ingressHost         | string | "app.example.com"                                                              | configure ingress hostname                                                                                                         | Y            |
 | jdbc                | Object |                                                                                | Java database connection. This is required. This needs to updated. See values.yaml for descriptions of supplied values.            | Y            |
-| efsFileSystemId     | string | ""                                                                             | Populate the elastic file system ID from your AWS console. This is required.                                                       | Y            |
-| kafka               | string | ""                                                                             | Deployed as MSK. Needed only if running Data Ingestion Service. Use either one of the two Kafka broker endpoints.                 | Y            |
+| efsFileSystemId     | string | ""                                                                             | Populate the elastic file system ID from your AWS console. This is required for AWS.                                               | Y            |
+| kafka               | string | ""                                                                             | Deployed as MSK. Needed only if running Data Ingestion Service. Use either one of the two Kafka broker endpoints.                  | Y            |
 | sftp                | object | {}                                                                             | It’s an OPTIONAL service.                                                                                                          | Y            |

--- a/charts/dataingestion-service/templates/deployment.yaml
+++ b/charts/dataingestion-service/templates/deployment.yaml
@@ -70,7 +70,7 @@ spec:
             - name: DI_AUTH_URI
               value: {{ .Values.authUri }}
             - name: DI_SFTP_ENABLED
-              value: {{ .Values.sftp.enabled }}
+              value: {{ .Values.sftp.enabled | default false | quote}}
             - name: DI_SFTP_HOST
               value: {{ .Values.sftp.host }}  
             - name: DI_SFTP_USER
@@ -86,11 +86,11 @@ spec:
             - name: SERVICE_TZ
               value: {{ .Values.timezone | default "UTC" }}
             - name: KAFKA_CONCURRENCY
-              value: "{{ .Values.kafkaConcurrency}}"
+              value: {{ .Values.kafkaConcurrency | default 1 | quote}}
             - name: API_PAYLOAD_MAX_SIZE
-              value: "{{ .Values.apiPayloadMaxSize}}"
+              value: {{ .Values.apiPayloadMaxSize }}
             - name: SPRING_PROFILES_ACTIVE
-              value: "{{ .Values.springBootProfile}}"
+              value: {{ .Values.springBootProfile }}
             - name: OBR_SPLITTING_ENABLED
               value: {{ .Values.features.obrSplitting.enabled | default false | quote}}
             - name: HL7_BATCH_SPLITTING_ENABLED

--- a/charts/dataingestion-service/values.yaml
+++ b/charts/dataingestion-service/values.yaml
@@ -1,14 +1,12 @@
 replicaCount: 1
 
-env: "prod"
-
 image:
-  #repository: "public.ecr.aws/o1z7u2g7/cdc-nbs-modernization/data-ingestion-service"
   repository: "quay.io/us-cdcgov/cdc-nbs-modernization/data-ingestion-service"
   pullPolicy: IfNotPresent
   tag: "v1.3.1"
 
 imagePullSecrets: []
+
 nameOverride: ""
 fullnameOverride: ""
 
@@ -31,41 +29,30 @@ service:
   port: 8081
   httpsPort: 443
 
-reportingService:
-  enabled: "true"
+# An ingress is created for the following enabled services.
+reportingService: # RTR
+  enabled: "false"
   personReportingServicePort: 8091
   organizationReportingServicePort: 8092
   investigationReportingServicePort: 8093
   observationReportingServicePort: 8094
   postProcessingReportingServicePort: 8095
   ldfdataReportingServicePort: 8097
-
-dataprocessingService:
+dataprocessingService: # data-processing-service - AKA Real Time Ingestion (RTI)
   enabled: "true"
   port: 8082
-
-nndService:
-  enabled: "true"
+nndService: # nnd-service
+  enabled: "false"
   port: 8081
-
-caseNotification:
+caseNotification: # case-notification-service
   enabled: "true"
   port: 8093
-
-compare:
-  enabled: "false"
+compare: # data-compare-api-service
+  enabled: "true"
   port: 8085
 
 ingress:
-  enabled: false
   className: "nginx"
-  tls:
-  - secretName: "data.EXAMPLE_DOMAIN"
-    hosts:
-    - "data.EXAMPLE_DOMAIN"
-
-traefikIngress:
-  enabled: false
 
 resources: {}
 
@@ -74,6 +61,7 @@ autoscaling:
   minReplicas: 1
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
+  #targetMemoryUtilizationPercentage: 80
 
 nodeSelector: {}
 
@@ -83,18 +71,19 @@ affinity: {}
 
 ingressHost: "data.EXAMPLE_DOMAIN"
 
-# dbserver is passed in as an environment variable. It is just the database endpoint
+# dbserver is just the database endpoint/hostname - not with the port number.
 jdbc:
   dbserver: "EXAMPLE_DB_ENDPOINT"
   username: "EXAMPLE_ODSE_DB_USER"
   password: "EXAMPLE_ODSE_DB_USER_PASSWORD"
 
 kafka:
-  cluster: "EXAMPLE_MSK_KAFKA_ENDPOINT"
+  cluster: "EXAMPLE_MSK_KAFKA_ENDPOINTS"
 
 log:
   path: "/usr/share/dataingestion/data"
 
+# This can be set to "aws" or "azure".
 cloudProvider: aws
 
 #Azure PVC Settings#
@@ -106,29 +95,26 @@ azure:
     storageRequest: 20Gi
 
 #AWS PVC Settings#
-
 pvc:
   diPvClaim:
     storageClass: efs-dataingestion
     storageRequest: 20Gi
 
+# Only for AWS
 efsFileSystemId: "EXAMPLE_EFS_ID"
 
-#authUri: "http://keycloak.keycloak.svc.cluster.local/realms/NBS"
+# More info at: https://cdcgov.github.io/NEDSS-SystemAdminGuide/docs/deploy-nbs7/microservices-deployment/case-notification.html#keycloak-configuration
 authUri: "http://keycloak.default.svc.cluster.local/auth/realms/NBS"
 
 sftp:
-  enabled: "EXAMPLE_SFTP_ENABLED"
+  enabled: false
   host: "EXAMPLE_SFTP_HOST"
   username: "EXAMPLE_SFTP_USER"
   password: "EXAMPLE_SFTP_PASS"
-  # need to fix search and replace for both these examples <<EXAMPLE_FIXME_SFTP_SEARCH_AND_REPLACE>>
-  #elrFileExtns: "EXAMPLE_SFTP_FILE_EXTNS"
-  #filePaths: "EXAMPLE_SFTP_FILE_PATHS"
-  elrFileExtns: "hl7,txt"
-  filePaths: "/"  
-# filePaths value should be comma seperated like "/,/LAB-1,/lab-2,/lab-2/lab2-sub-folder"
-##################################
+  elrFileExtns: "EXAMPLE_SFTP_FILE_EXTNS" # e.g. "hl7,txt"
+  filePaths: "EXAMPLE_SFTP_FILE_PATHS" # e.g. "/"
+  # filePaths value should be comma seperated like "/,/LAB-1,/lab-2,/lab-2/lab2-sub-folder"
+
 features:
   obrSplitting:
     enabled: false
@@ -137,7 +123,7 @@ features:
 
 apiPayloadMaxSize: "100MB"
 
-# To enable swagger: https://<data.EXAMPLE_DOMAIN>/ingestion/swagger-ui/index.html#/ 
+# When this is set to "dev" then Swagger will be enabled and accessible via https://<data.EXAMPLE_DOMAIN>/ingestion/swagger-ui/index.html
 springBootProfile: "dev"
 
 # Override available for readiness and liveness probes: path, port, initialDelaySeconds, periodSeconds, failureThreshold

--- a/charts/dataingestion-service/values.yaml
+++ b/charts/dataingestion-service/values.yaml
@@ -48,7 +48,8 @@ caseNotification: # case-notification-service
   enabled: "true"
   port: 8093
 compare: # data-compare-api-service
-  enabled: "true"
+  # Note that when the reportingService.enabled value above is "false" then the following value should be "false" as well.
+  enabled: "false"
   port: 8085
 
 ingress:


### PR DESCRIPTION
fyi on our dev73 environment I have run `helm install` for the changes from this PR:
```
jolson@Joshs-Skylight-MBP in ~/git/CDCgov/NEDSS-Helm/charts on Josh/fix_dataingestion-service
❯ helm install dataingestion-service -f ./dataingestion-service/values.yaml dataingestion-service
NAME: dataingestion-service
LAST DEPLOYED: Tue May 26 15:35:26 2026
NAMESPACE: default
STATUS: deployed
REVISION: 1
❯ date; kubectl get pods | egrep "NAME|ingest"
Tue May 26 16:20:52 CDT 2026
NAME                                       READY   STATUS    RESTARTS   AGE
dataingestion-service-7b5c55946f-h5gs6     2/2     Running   0          45m
```