### PR TITLE
add reporting pipeline service ingress rules

### DIFF
--- a/charts/nbs-ingress/templates/nginx-ingress.yaml
+++ b/charts/nbs-ingress/templates/nginx-ingress.yaml
@@ -158,49 +158,14 @@ spec:
                 port:
                   number: {{ .Values.data.caseNotification.port }}
           {{- end }}
-          {{- if .Values.data.reporting.enabled }}
-          - path: "/reporting/person-svc/"
+          {{- if .Values.data.reportingPipeline.enabled }}
+          - path: "/reporting-pipeline-svc/"
             pathType: Prefix
             backend:
               service:
-                name: {{ .Values.data.reporting.person.serviceName }}
+                name: {{ .Values.data.reportingPipeline.serviceName }}
                 port:
-                  number: {{ .Values.data.reporting.person.port }}
-          - path: "/reporting/organization-svc/"
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ .Values.data.reporting.organization.serviceName }}
-                port:
-                  number: {{ .Values.data.reporting.organization.port }}
-          - path: "/reporting/investigation-svc/"
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ .Values.data.reporting.investigation.serviceName }}
-                port:
-                  number: {{ .Values.data.reporting.investigation.port }}
-          - path: "/reporting/observation-svc/"
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ .Values.data.reporting.observation.serviceName }}
-                port:
-                  number: {{ .Values.data.reporting.observation.port }}
-          - path: "/reporting/post-processing-svc/"
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ .Values.data.reporting.postProcessing.serviceName }}
-                port:
-                  number: {{ .Values.data.reporting.postProcessing.port }}
-          - path: "/reporting/ldfdata-svc/"
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ .Values.data.reporting.ldfdata.serviceName }}
-                port:
-                  number: {{ .Values.data.reporting.ldfdata.port }}
+                  number: {{ .Values.data.reportingPipeline.port }}
           {{- end }}
           {{- if .Values.data.compare.enabled }}
           - path: "/comparison/"

--- a/charts/nbs-ingress/templates/traefik-ingress-dataingestion.yaml
+++ b/charts/nbs-ingress/templates/traefik-ingress-dataingestion.yaml
@@ -32,49 +32,14 @@ spec:
                 port:
                   number: {{ .Values.data.ingestion.port }}
           {{- end }}
-          {{- if .Values.data.reporting.enabled }}
-          - path: "/reporting/person-svc/"
+          {{- if .Values.data.reportingPipeline.enabled }}
+          - path: "/reporting-pipeline-svc/"
             pathType: Prefix
             backend:
               service:
-                name: {{ .Values.data.reporting.person.serviceName }}
+                name: {{ .Values.data.reportingPipeline.serviceName }}
                 port:
-                  number: {{ .Values.data.reporting.person.port }}
-          - path: "/reporting/organization-svc/"
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ .Values.data.reporting.organization.serviceName }}
-                port:
-                  number: {{ .Values.data.reporting.organization.port }}
-          - path: "/reporting/investigation-svc/"
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ .Values.data.reporting.investigation.serviceName }}
-                port:
-                  number: {{ .Values.data.reporting.investigation.port }}
-          - path: "/reporting/observation-svc/"
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ .Values.data.reporting.observation.serviceName }}
-                port:
-                  number: {{ .Values.data.reporting.observation.port }}
-          - path: "/reporting/post-processing-svc/"
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ .Values.data.reporting.postProcessing.serviceName }}
-                port:
-                  number: {{ .Values.data.reporting.postProcessing.port }}
-          - path: "/reporting/ldfdata-svc/"
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ .Values.data.reporting.ldfdata.serviceName }}
-                port:
-                  number: {{ .Values.data.reporting.ldfdata.port }}
+                  number: {{ .Values.data.reportingPipeline.port }}
           {{- end }}
           {{- if .Values.data.dataProcessing.enabled }}
           - path: "/rti/"

--- a/charts/nbs-ingress/values.yaml
+++ b/charts/nbs-ingress/values.yaml
@@ -73,27 +73,11 @@ data:
     enabled: true
     serviceName: "dataingestion-service"
     port: 8081
-  # Reporting Services
-  reporting:
-    enabled: false
-    person:
-      serviceName: "person-reporting-service"
-      port: 8091
-    organization:
-      serviceName: "organization-reporting-service"
-      port: 8092
-    investigation:
-      serviceName: "investigation-reporting-service"
-      port: 8093
-    observation:
-      serviceName: "observation-reporting-service"
-      port: 8094
-    postProcessing:
-      serviceName: "post-processing-reporting-service"
-      port: 8095
-    ldfdata:
-      serviceName: "ldfdata-reporting-service"
-      port: 8096
+  # Reporting Pipeline
+  reportingPipeline:
+    enabled: true
+    serviceName: "reporting-pipeline-service"
+    port: 8095
   # Data Processing
   dataProcessing:
     enabled: true

--- a/charts/reporting-pipeline-service/templates/deployment.yaml
+++ b/charts/reporting-pipeline-service/templates/deployment.yaml
@@ -94,8 +94,6 @@ spec:
             # Feature flags:
             - name: FF_ES_ENABLE
               value: {{ .Values.featureFlag.elasticSearchEnable | quote }}
-            - name: FF_PHC_DM_ENABLE
-              value: {{ .Values.featureFlag.phcDatamartEnable | quote }}
             - name: FF_THREAD_POOL_SIZE
               value: {{ .Values.featureFlag.threadPoolSize | quote }}
             - name: FF_POST_PROCESSING_ENABLE

--- a/charts/reporting-pipeline-service/values.yaml
+++ b/charts/reporting-pipeline-service/values.yaml
@@ -15,7 +15,6 @@ timezone: "UTC"
 image:
   repository: "quay.io/us-cdcgov/cdc-nbs-modernization/reporting-pipeline-service"
   tag: "v1.3.0-prerelease.31084a3"
-# pullPolicy: IfNotPresent
 
 podAnnotations:
   prometheus.io/scrape: "true"
@@ -36,7 +35,6 @@ resources:
 
 featureFlag:
   elasticSearchEnable: "false"
-  phcDatamartEnable: "false"
   threadPoolSize: "1"
   postProcessingEnable: "true"
 
@@ -44,19 +42,15 @@ probes:
   readiness:
     enabled: true
     initialDelaySeconds: 60
-#   periodSeconds: 10
-#   failureThreshold: 5
   liveness:
     enabled: true
-#   initialDelaySeconds: 60
-#   periodSeconds: 30
-#   failureThreshold: 5
 
 secrets:
   secretName: "reporting-pipeline-service-access"
   jdbc:
-    connection_url: "db_connection_url" # The database for this NBS environment
-    # The credentials that the service created by this chart is to use to connect to the database:
+    # The reporting database for this NBS environment
+    connection_url: "db_connection_url"
+    # The credentials used to run this service
     username: "db_user"
     password: "db_password"
   kafka:

--- a/charts/reporting-pipeline-service/values.yaml
+++ b/charts/reporting-pipeline-service/values.yaml
@@ -43,8 +43,13 @@ probes:
   readiness:
     enabled: true
     initialDelaySeconds: 60
+#   periodSeconds: 10
+#   failureThreshold: 5
   liveness:
     enabled: true
+#   initialDelaySeconds: 60
+#   periodSeconds: 30
+#   failureThreshold: 5
 
 secrets:
   secretName: "reporting-pipeline-service-access"

--- a/charts/reporting-pipeline-service/values.yaml
+++ b/charts/reporting-pipeline-service/values.yaml
@@ -15,6 +15,7 @@ timezone: "UTC"
 image:
   repository: "quay.io/us-cdcgov/cdc-nbs-modernization/reporting-pipeline-service"
   tag: "v1.3.0-prerelease.31084a3"
+# pullPolicy: IfNotPresent
 
 podAnnotations:
   prometheus.io/scrape: "true"


### PR DESCRIPTION
## Description
This pull request updates the Helm configuration for reporting pipeline services ingress rules in the NBS deployment. Previously, separate ingress rules and paths were maintained for multiple individual reporting microservices, such as person-svc, organization-svc, investigation-svc, and others. These individual service paths have been replaced by a single, unified ingress rule routing to the centralized `reporting-pipeline-service` at `/reporting-pipeline-svc/`. Additionally, an untested feature flag (`FF_PHC_DM_ENABLE`) has been cleaned up and removed from the `reporting-pipeline-service` deployment.


