### PR TITLE
refactor(reporting-pipeline): move db/kafka config

### DIFF
--- a/charts/reporting-pipeline-service/templates/deployment.yaml
+++ b/charts/reporting-pipeline-service/templates/deployment.yaml
@@ -69,11 +69,11 @@ spec:
                   name: kafka-connect-config
                   key: KAFKA_CONNECT_URL
 
-            - name: DB_CONNECTION_URL # Note that in CDCgov/NEDSS-DataReporting/docker-compose.yaml this variable is named DB_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.secrets.secretName | quote }}
-                  key: {{ .Values.secrets.jdbc.connection_url | quote }}
+            - name: KAFKA_BOOTSTRAP_SERVER
+              value: {{ .Values.kafka.cluster | quote }}
+            - name: DB_CONNECTION_URL
+              value: {{ .Values.jdbc.connection_url | quote }}
+
             - name: DB_USERNAME
               valueFrom:
                 secretKeyRef:
@@ -84,12 +84,6 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.secrets.secretName | quote }}
                   key: {{ .Values.secrets.jdbc.password | quote }}
-
-            - name: KAFKA_BOOTSTRAP_SERVER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.secrets.secretName | quote }}
-                  key: {{ .Values.secrets.kafka.cluster | quote }}
 
             # Feature flags:
             - name: FF_ES_ENABLE

--- a/charts/reporting-pipeline-service/templates/deployment.yaml
+++ b/charts/reporting-pipeline-service/templates/deployment.yaml
@@ -61,12 +61,12 @@ spec:
             - name: DEBEZIUM_CONNECT_URL
               valueFrom:
                 configMapKeyRef:
-                  name: debezium-connect-config
+                  name: debezium-rtr-connect
                   key: DEBEZIUM_CONNECT_URL
             - name: KAFKA_CONNECT_URL
               valueFrom:
                 configMapKeyRef:
-                  name: kafka-connect-config
+                  name: cp-kafka-connect-sqlserver-connect
                   key: KAFKA_CONNECT_URL
 
             - name: KAFKA_BOOTSTRAP_SERVER

--- a/charts/reporting-pipeline-service/values.yaml
+++ b/charts/reporting-pipeline-service/values.yaml
@@ -50,16 +50,21 @@ probes:
 #   initialDelaySeconds: 60
 #   periodSeconds: 30
 #   failureThreshold: 5
+#
+
+jdbc:
+  # jdbc url connection string for the reporting database
+  # e.g. jdbc:sqlserver://<db-host>:1433;databaseName=RDB;encrypt=true;trustServerCertificate=true;
+  connection_url: "db_connection_url"
+
+kafka:
+  # The following configuration setting is a comma-separated list of the endpoint(s) of Kafka broker(s) for the given Kubernetes cluster.
+  # e.g. for an AWS MSK provisioned cluster: b-<broker-id>.<cluster-name>.<unique-id>.c<cluster-number>.<aws-region>.amazonaws.com:<port>
+  cluster: "kafka_cluster_url"
 
 secrets:
   secretName: "reporting-pipeline-service-access"
   jdbc:
-    # The reporting database for this NBS environment
-    connection_url: "db_connection_url"
     # The credentials used to run this service
     username: "db_user"
     password: "db_password"
-  kafka:
-    # The following configuration setting is a comma-separated list of the endpoint(s) of Kafka broker(s) for the given Kubernetes cluster.
-    # e.g. for an AWS MSK provisioned cluster: b-<broker-id>.<cluster-name>.<unique-id>.c<cluster-number>.<aws-region>.amazonaws.com:<port>
-    cluster: "kafka_cluster_url"

--- a/k8-manifests/nbs-secrets.yaml
+++ b/k8-manifests/nbs-secrets.yaml
@@ -10,7 +10,5 @@ type: Opaque
 # Reference info: CDCgov/NEDSS-SystemAdminGuide/docs/4_initial_kubernetes_deployment/1_creating_kubernetes_secrets.md
 stringData:
   # There is info about the following secrets at ../charts/reporting-pipeline-service/values.yaml
-  db_connection_url: "jdbc:sqlserver://EXAMPLE_DB_HOSTNAME:1433;databaseName=EXAMPLE_DB_NAME;encrypt=false;trustServerCertificate=true;"
   db_user: "EXAMPLE_DB_USER"
   db_password: "EXAMPLE_DB_PASSWORD"
-  kafka_cluster_url: "EXAMPLE_KAFKA_CLUSTER_URL"


### PR DESCRIPTION
## Description
Move `DB_CONNECTION_URL` and `KAFKA_BOOTSTRAP_SERVER` from `secrets` to top-level configuration blocks in `values.yaml`. Update the deployment template to reference these new locations instead of secret keys.