### PR TITLE
Add resource requests/limits for elasticsearch, nifi, modernization-api

### DIFF
--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -36,7 +36,11 @@ ingress:
 
 resources: 
   limits:
-    memory: "6Gi"
+    cpu: "1000m"
+    memory: "3Gi"
+  requests:
+    cpu: "500m"
+    memory: "1536Mi"
 
 autoscaling:
   enabled: false

--- a/charts/modernization-api/values.yaml
+++ b/charts/modernization-api/values.yaml
@@ -41,7 +41,11 @@ nbsExternalName: app-classic.EXAMPLE_DOMAIN
 
 resources:
   limits:
-    memory: "4Gi"
+    cpu: "500m"
+    memory: "2Gi"
+  requests:
+    cpu: "250m"
+    memory: "768Mi"
 
 autoscaling:
   enabled: false

--- a/charts/nifi/values.yaml
+++ b/charts/nifi/values.yaml
@@ -51,7 +51,11 @@ ingress:
 
 resources: 
   limits:
-    memory: "6Gi"
+    cpu: "1000m"
+    memory: "3Gi"
+  requests:
+    cpu: "500m"
+    memory: "1536Mi"
 
 autoscaling:
   enabled: false
@@ -87,8 +91,8 @@ efsFileSystemId: "EXAMPLE_EFS_ID"
 ### Nifi Configurations ###
 
 jvmheap:
-  init: "4g"
-  max: "4g"
+  init: "1g"
+  max: "2g"
 
 # jdbcConnectionString is passed in as an override and all values must be supplied. 
 # Replace <db_endpoint>, <database>, <username>, and <password> in the following:


### PR DESCRIPTION
## Summary
NBS7 Helm charts for elasticsearch, nifi, and modernization-api either had only resources.limits (no requests) or oversized defaults for Small STLT clusters. When only limits are defined, Kubernetes auto-sets requests equal to limits — meaning Elasticsearch alone was guaranteeing 6GB on a node that only has 8GB. This caused node crashes on dev73 when multiple pods landed on the same node.

Ticket reference https://cdc-nbs.atlassian.net/browse/DEV-548

Before:

- elasticsearch: limits.memory 6Gi only → 6Gi guaranteed
- nifi: limits.memory 6Gi only (Octopus overrides to 1.5Gi on Skylight envs, but STLTs get the 6Gi default)
- modernization-api: limits.memory 4Gi only → 4Gi guaranteed
- Total guaranteed by just these 3: 16GB out of 19.5GB allocatable — leaving 3.5GB for every other service

## Changes
Added resources.requests and right-sized resources.limits for Small STLT baseline (3 × m5.large):

Service | Request Mem | Request CPU | Limit Mem | Limit CPU
-- | -- | -- | -- | --
elasticsearch | 1536Mi | 500m | 3Gi | 1000m
nifi | 1536Mi | 500m | 3Gi | 1000m
modernization-api | 768Mi | 250m | 2Gi | 500m

</div>
<p class="font-claude-response-body break-words whitespace-normal">Also reduced nifi <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">jvmheap</code> from init=4g/max=4g to init=1g/max=2g to stay within the new container limit.</p>
<p class="font-claude-response-body break-words whitespace-normal"><strong>After:</strong> Total guaranteed by these 3: <strong>~3.75GB</strong> — down from 16GB.</p><!--EndFragment-->
</body>
</html>

## Testing 

<img width="1082" height="285" alt="image" src="https://github.com/user-attachments/assets/cf4590ee-2afa-4e61-a3bc-c1a59c18c7a0" />
