### PR TITLE
local-dev w/minikube

### DIFF
--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -52,6 +52,49 @@ kubectl get pods -w
 kubectl logs -f deployment/nedssdev
 ```
 
+## Using a Local Docker Image in Minikube
+
+If you want to run a Helm chart against a locally built image instead of pulling from a remote registry, build the image into Minikube’s Docker environment and set the chart to use `imagePullPolicy: Never`.
+
+Example for `reporting-pipeline-service`:
+
+```bash
+# Point Docker at the Minikube daemon for the nbs-local profile
+eval "$(minikube -p nbs-local docker-env)"
+
+# Build the image locally inside Minikube
+cd <path-to-reporting-pipeline-service-repo>
+docker build -t reporting-pipeline-service:local .
+```
+
+Then install or upgrade the chart with local image values:
+
+```yaml
+# local-dev/values/reporting-pipeline-service-local.yaml
+image:
+  repository: reporting-pipeline-service
+  tag: local
+  pullPolicy: Never
+```
+
+```bash
+helm upgrade --install reporting-pipeline-service ./charts/reporting-pipeline-service \
+  -f local-dev/values/reporting-pipeline-service-local.yaml
+```
+
+If you built the image with your normal Docker daemon instead, load it into Minikube directly:
+
+```bash
+minikube -p nbs-local image load reporting-pipeline-service:local
+```
+
+After the install, if the pod does not start, confirm the image is present in Minikube:
+
+```bash
+minikube -p nbs-local image ls | grep reporting-pipeline-service
+kubectl describe pod -l app.kubernetes.io/name=reporting-pipeline-service
+```
+
 ## Connection Details
 
 ### In-cluster (helm chart values)

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -1,0 +1,115 @@
+# NBS Local Development (Minikube)
+
+This directory provides the scripts and manifests needed to stand up a local NBS environment
+using [minikube](https://minikube.sigs.k8s.io/). The goal is to give developers a working
+cluster with the core infrastructure services running — database, legacy application server, and
+message broker — so that the Helm charts in this repository can be deployed and tested locally
+without needing access to a shared or cloud environment.
+
+The scripts here provision the services that **do not** have Helm charts in this repo
+(nedssdb, nedssdev, and kafka) as standalone Kubernetes manifests. Once those are up and
+healthy, the cluster is ready for developers to install and iterate on any of the charts
+under `charts/` against a realistic local stack.
+
+> **Note:** These manifests are intentionally separate from the production Helm charts.
+> The `nbs6` chart targets Windows nodes and the `kafka` chart uses an AWS EBS StorageClass —
+> neither works on a local Linux-based minikube node.
+
+## Stack
+
+| Service | Image | Purpose |
+|---------|-------|---------|
+| **nedssdb** | `ghcr.io/cdcent/nedssdb:6.0.17.0-replacement-beta` | SQL Server with NBS databases pre-seeded |
+| **nedssdev** | `ghcr.io/cdcent/nedssdev:6.0.18.1` | WildFly application server (NBS classic) |
+| **kafka** | `confluentinc/cp-kafka:7.8.7` | Kafka broker (KRaft mode — no Zookeeper) |
+
+## Prerequisites
+
+- [helm](https://helm.sh/docs/intro/install)
+- [minikube](https://minikube.sigs.k8s.io/docs/start/) >= 1.32
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
+- [Docker](https://docs.docker.com/get-docker/) (used as the minikube driver)
+- At least **8 GB RAM** and **2 CPUs** available to allocate
+
+## Quick Start
+
+```bash
+# From the repo root
+./local-dev/scripts/start.sh
+```
+
+The script will:
+1. Start a minikube cluster (`nbs-local` profile) with 2 CPUs and 8 GB RAM
+2. Enable the ingress addon
+3. Deploy nedssdb and wait for it to be ready (~1-2 min)
+4. Deploy kafka (KRaft mode)
+5. Deploy nedssdev (WildFly)
+
+nedssdev takes a few minutes to fully initialize after the pod starts. Monitor progress:
+
+```bash
+kubectl get pods -w
+kubectl logs -f deployment/nedssdev
+```
+
+## Connection Details
+
+### In-cluster (helm chart values)
+
+When deploying charts from this repo into the same cluster, use these hostnames and ports:
+
+| Service | Host | Port |
+|---|---|---|
+| nedssdb (SQL Server) | `nbs-mssql` | `1433` |
+| kafka | `kafka` | `29092` |
+
+Kafka runs in KRaft mode (no Zookeeper). In-cluster clients connect on the `INTERNAL` listener at
+`kafka:29092`. Port `9092` is the `EXTERNAL` listener and advertises `localhost:9092` — it's only
+useful via port-forward from your laptop.
+
+### From your laptop (port-forward)
+
+To connect local tooling (SQL clients, kafka CLI, browser) to the in-cluster services:
+
+```bash
+kubectl port-forward svc/nbs-mssql 1433:1433   # SQL Server -> localhost:1433
+kubectl port-forward svc/kafka    9092:9092   # Kafka      -> localhost:9092
+kubectl port-forward svc/nedssdev 7001:7001     # NBS UI     -> http://localhost:7001/nbs/login
+```
+
+The start script prints these details again after deployment.
+
+## Credentials
+
+Database credentials are defined in `manifests/nedssdb.yaml` under the `nbs-mssql-secret` Secret.
+The 'sa-password' value can be adjusted if needed, but the others are set to match the DB image.
+
+| Secret key | Default value |
+|---|---|
+| `sa-password` | `PizzaIsGood33!` |
+| `odse-user` / `odse-password` | `nbs_ods` / `ods` |
+| `srte-user` / `srte-password` | `nbs_srte` / `admin` |
+| `rdb-user` / `rdb-password` | `nbs_rdb` / `rdb` |
+
+## Stopping
+
+```bash
+./local-dev/scripts/stop.sh
+```
+
+To fully remove the cluster and reclaim disk:
+
+```bash
+minikube delete --profile nbs-local
+```
+
+## Customizing Resources
+
+The scripts respect environment variables for minikube sizing:
+
+```bash
+MINIKUBE_CPUS=2 MINIKUBE_MEMORY=8g ./local-dev/scripts/start.sh
+```
+
+Default resource requests in the manifests are set conservatively for local dev and are much lower
+than the production values (e.g. nedssdev uses `JAVA_MEMORY=2g` vs `10g` in production).

--- a/local-dev/manifests/kafka.yaml
+++ b/local-dev/manifests/kafka.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kafka-pv-claim
+  namespace: default
+  labels:
+    app: kafka
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: standard
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+  namespace: default
+  labels:
+    app: kafka
+spec:
+  type: ClusterIP
+  selector:
+    app: kafka
+  ports:
+    - name: internal
+      port: 29092
+      targetPort: 29092
+    - name: external
+      port: 9092
+      targetPort: 9092
+    - name: controller
+      port: 29093
+      targetPort: 29093
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka
+  namespace: default
+  labels:
+    app: kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      hostname: kafka
+      restartPolicy: Always
+      enableServiceLinks: false
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: kafka
+          image: confluentinc/cp-kafka:7.8.7
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 29092
+            - containerPort: 9092
+            - containerPort: 29093
+          env:
+            # KRaft Configuration
+            - name: KAFKA_NODE_ID
+              value: "1"
+            - name: KAFKA_PROCESS_ROLES
+              value: "broker,controller"
+            - name: KAFKA_CONTROLLER_QUORUM_VOTERS
+              value: "1@kafka:29093"
+            - name: KAFKA_CONTROLLER_LISTENER_NAMES
+              value: "CONTROLLER"
+            - name: CLUSTER_ID
+              value: "RwB4L8JMReqMdSiPoP-9Og"
+            # Listener Configuration
+            - name: KAFKA_LISTENERS
+              value: "INTERNAL://0.0.0.0:29092,EXTERNAL://0.0.0.0:9092,CONTROLLER://0.0.0.0:29093"
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: "INTERNAL://kafka:29092,EXTERNAL://localhost:9092"
+            - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+              value: "INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT"
+            - name: KAFKA_INTER_BROKER_LISTENER_NAME
+              value: "INTERNAL"
+            # Topic Configuration
+            - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS
+              value: "0"
+            - name: KAFKA_TRANSACTION_STATE_LOG_MIN_ISR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
+              value: "1"
+          volumeMounts:
+            - mountPath: /var/lib/kafka
+              name: kafka-storage
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "200m"
+            limits:
+              memory: "1Gi"
+      volumes:
+        - name: kafka-storage
+          persistentVolumeClaim:
+            claimName: kafka-pv-claim

--- a/local-dev/manifests/nedssdb.yaml
+++ b/local-dev/manifests/nedssdb.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nbs-mssql-secret
+  namespace: default
+type: Opaque
+stringData:
+  sa-password: "PizzaIsGood33!"
+  odse-user: "nbs_ods"
+  odse-password: "ods"
+  srte-user: "nbs_srte"
+  srte-password: "admin"
+  rdb-user: "nbs_rdb"
+  rdb-password: "rdb"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nbs-mssql
+  namespace: default
+  labels:
+    app: nbs-mssql
+spec:
+  type: ClusterIP
+  selector:
+    app: nbs-mssql
+  ports:
+    - name: mssql
+      port: 1433
+      targetPort: 1433
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nbs-mssql
+  namespace: default
+  labels:
+    app: nbs-mssql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nbs-mssql
+  template:
+    metadata:
+      labels:
+        app: nbs-mssql
+    spec:
+      containers:
+        - name: nbs-mssql
+          image: ghcr.io/cdcent/nedssdb:6.0.17.0-replacement-beta
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 1433
+          env:
+            - name: DATABASE_VERSION
+              value: "6.0.18.1"
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: nbs-mssql-secret
+                  key: sa-password
+          readinessProbe:
+            tcpSocket:
+              port: 1433
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 10
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "500m"
+            limits:
+              memory: "4Gi"

--- a/local-dev/manifests/nedssdev.yaml
+++ b/local-dev/manifests/nedssdev.yaml
@@ -1,0 +1,102 @@
+---
+# The nbs6 helm chart targets Windows nodes (hardcoded nodeSelector).
+# This standalone manifest is used for local minikube development instead.
+apiVersion: v1
+kind: Service
+metadata:
+  name: nedssdev
+  namespace: default
+  labels:
+    app: nedssdev
+spec:
+  type: ClusterIP
+  selector:
+    app: nedssdev
+  ports:
+    - name: http
+      port: 7001
+      targetPort: 7001
+    - name: https
+      port: 7443
+      targetPort: 7443
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nedssdev
+  namespace: default
+  labels:
+    app: nedssdev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nedssdev
+  template:
+    metadata:
+      labels:
+        app: nedssdev
+    spec:
+      containers:
+        - name: nedssdev
+          image: ghcr.io/cdcent/nedssdev:6.0.18.1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 7001
+          env:
+            - name: DATABASE_ENDPOINT
+              value: "nbs-mssql"
+            - name: odse_user
+              valueFrom:
+                secretKeyRef:
+                  name: nbs-mssql-secret
+                  key: odse-user
+            - name: odse_pass
+              valueFrom:
+                secretKeyRef:
+                  name: nbs-mssql-secret
+                  key: odse-password
+            - name: srte_user
+              valueFrom:
+                secretKeyRef:
+                  name: nbs-mssql-secret
+                  key: srte-user
+            - name: srte_pass
+              valueFrom:
+                secretKeyRef:
+                  name: nbs-mssql-secret
+                  key: srte-password
+            - name: rdb_user
+              valueFrom:
+                secretKeyRef:
+                  name: nbs-mssql-secret
+                  key: rdb-user
+            - name: rdb_pass
+              valueFrom:
+                secretKeyRef:
+                  name: nbs-mssql-secret
+                  key: rdb-password
+            - name: DISABLED_SCHEDULED_TASKS
+              value: "SendAlertEMail.bat,DeDuplicationSimilarBatchProcess.bat,UserProfileUpdateProcess.bat"
+            - name: JAVA_MEMORY
+              value: "2g"
+          readinessProbe:
+            httpGet:
+              path: /nbs/login
+              port: 7001
+            initialDelaySeconds: 120
+            periodSeconds: 30
+            failureThreshold: 10
+          livenessProbe:
+            httpGet:
+              path: /nbs/login
+              port: 7001
+            initialDelaySeconds: 180
+            periodSeconds: 60
+            failureThreshold: 5
+          resources:
+            requests:
+              memory: "4Gi"
+              cpu: "500m"
+            limits:
+              memory: "6Gi"

--- a/local-dev/scripts/start.sh
+++ b/local-dev/scripts/start.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFESTS_DIR="$SCRIPT_DIR/../manifests"
+
+MINIKUBE_CPUS="${MINIKUBE_CPUS:-2}"
+MINIKUBE_MEMORY="${MINIKUBE_MEMORY:-8g}"
+MINIKUBE_PROFILE="${MINIKUBE_PROFILE:-nbs-local}"
+
+echo "==> Starting minikube (profile: $MINIKUBE_PROFILE)"
+minikube start \
+  --profile "$MINIKUBE_PROFILE" \
+  --cpus "$MINIKUBE_CPUS" \
+  --memory "$MINIKUBE_MEMORY" \
+  --driver docker
+
+echo "==> Enabling ingress addon"
+minikube addons enable ingress --profile "$MINIKUBE_PROFILE"
+
+echo "==> Deploying nedssdb (SQL Server)"
+kubectl apply -f "$MANIFESTS_DIR/nedssdb.yaml"
+
+echo "==> Deploying kafka (KRaft mode)"
+kubectl apply -f "$MANIFESTS_DIR/kafka.yaml"
+
+echo "==> Waiting for nedssdb to be ready (this can take 1-2 minutes)..."
+kubectl rollout status deployment/nbs-mssql --timeout=180s
+
+echo "==> Deploying nedssdev (WildFly)"
+kubectl apply -f "$MANIFESTS_DIR/nedssdev.yaml"
+
+echo ""
+echo "==> All services deployed."
+echo "    nedssdev takes a few minutes to reach ready state."
+echo "    Monitor with: kubectl get pods -w"
+echo ""
+echo "┌──────────────────────────────────────────────────────────────────┐"
+echo "│  In-cluster connection details (use these in helm chart values)  │"
+echo "├───────────┬──────────────────────────────────────────────────────┤"
+echo "│  nedssdb  │  host:      nbs-mssql:1433                           │"
+echo "│  kafka    │  bootstrap: kafka:29092    (INTERNAL listener)       │"
+echo "└───────────┴──────────────────────────────────────────────────────┘"
+echo ""
+echo "==> To connect from your laptop, use port-forward:"
+echo "    kubectl port-forward svc/nbs-mssql 1433:1433   # SQL Server -> localhost:1433"
+echo "    kubectl port-forward svc/kafka     9092:9092   # Kafka      -> localhost:9092"
+echo "    kubectl port-forward svc/nedssdev  7001:7001   # NBS UI     -> http://localhost:7001/nbs/login"

--- a/local-dev/scripts/stop.sh
+++ b/local-dev/scripts/stop.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFESTS_DIR="$SCRIPT_DIR/../manifests"
+
+MINIKUBE_PROFILE="${MINIKUBE_PROFILE:-nbs-local}"
+
+echo "==> Removing deployed resources"
+kubectl delete -f "$MANIFESTS_DIR/nedssdev.yaml" --ignore-not-found
+kubectl delete -f "$MANIFESTS_DIR/kafka.yaml" --ignore-not-found
+kubectl delete -f "$MANIFESTS_DIR/nedssdb.yaml" --ignore-not-found
+
+echo "==> Stopping minikube (profile: $MINIKUBE_PROFILE)"
+minikube stop --profile "$MINIKUBE_PROFILE"
+
+echo "==> Done. Run 'minikube delete --profile $MINIKUBE_PROFILE' to fully remove the cluster."


### PR DESCRIPTION
## Description
- This PR introduces a `local-dev` directory to the repository, providing the necessary scripts and Kubernetes manifests to stand up a local NBS development environment using Minikube.
- The new infrastructure includes standalone deployments for core services (`nedssdb`, `nedssdev`, and `kafka`) that do not have existing Helm charts in this repository, enabling developers to test and iterate on Helm charts locally without needing an external environment.
- Documentation and helper scripts are included to streamline the setup, teardown, and port-forwarding processes for local development.

