### PR TITLE
(chore): fix RTR default feature flags and kafka-connect default

### DIFF
--- a/charts/kafka-connect-sink/values.yaml
+++ b/charts/kafka-connect-sink/values.yaml
@@ -16,7 +16,7 @@ imagePullPolicy: IfNotPresent
 ## Specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.
 ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
-imagePullSecrets:
+imagePullSecrets: []
 
 servicePort: 8083
 

--- a/charts/reporting-pipeline-service/values.yaml
+++ b/charts/reporting-pipeline-service/values.yaml
@@ -33,9 +33,9 @@ resources:
     cpu: "125m"
 
 featureFlag:
-  elasticSearchEnable: "false"
   threadPoolSize: "1"
-  postProcessingEnable: "true"
+  elasticSearchEnable: "false"
+  postProcessingEnable: "false"
 
 probes:
   readiness:


### PR DESCRIPTION
## Description
This PR updates the configuration values for the `kafka-connect-sink` and `reporting-pipeline-service` Helm charts. Specifically, it updates `imagePullSecrets` for `kafka-connect-sink` to resolve potential deployment errors and disables `postProcessingEnable` in `reporting-pipeline-service` to align with the intended service configuration (we want STLTs to start RTR with post-processing off during initial seeding).


