### PR TITLE
Update reporting-pipeline-service pre-release tag

### DIFF
--- a/charts/debezium/values.yaml
+++ b/charts/debezium/values.yaml
@@ -31,6 +31,7 @@ connect:
       memory: 1Gi
 
   properties:
+    bootstrap_server: "EXAMPLE_KAFKA_ENDPOINT_AND_PORT"
     group_id: "debezium-odse-srte-connector-v081525"
     topics_basename: "debezium-odse-srte-connector-v081525"
     default_replication_factor: 2
@@ -38,17 +39,12 @@ connect:
     default_cleanup: "compact"
     sql_server_agent_override: false
     sql_server_agent_status: ""
-    bootstrap_server: "EXAMPLE_KAFKA_ENDPOINT"
 
   env:
-    - name: BOOTSTRAP_SERVERS
-      value: "EXAMPLE_KAFKA_ENDPOINT"
     - name: LOG_LEVEL
       value: "INFO"
     - name: KAFKA_LOG4J_OPTS
       value: "-Dlog4j.configuration=file:/kafka/config/log4j.properties"
-    - name: NAME
-      value: "debezium-odse-srte-connector-v081525"
     - name: TZ
       value: "UTC"
 

--- a/charts/kafka-connect-sink/templates/deployment.yaml
+++ b/charts/kafka-connect-sink/templates/deployment.yaml
@@ -73,6 +73,7 @@ spec:
             - "bash"
             - "-c"
             - |
+              set -euo pipefail
               confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:10.7.6
               exec /etc/confluent/docker/run
           env:

--- a/charts/kafka-connect-sink/values.yaml
+++ b/charts/kafka-connect-sink/values.yaml
@@ -97,8 +97,7 @@ prometheus:
 ## You can list load balanced service endpoint, or list of all brokers (which is hard in K8s).  e.g.:
 ## bootstrapServers: "PLAINTEXT://dozing-prawn-kafka-headless:9092"
 kafka:
-  # this may not be right: bootstrapServers: "EXAMPLE_FIXME_KAFKA_ENDPOINT"
-  bootstrapServers: "EXAMPLE_KAFKA_ENDPOINT"
+  bootstrapServers: "EXAMPLE_KAFKA_ENDPOINT_AND_PORT"
   default_replication_factor: 2
   default_partitions: 10
   default_cleanup: "compact"

--- a/charts/reporting-pipeline-service/values.yaml
+++ b/charts/reporting-pipeline-service/values.yaml
@@ -12,7 +12,7 @@ timezone: "UTC"
 
 image:
   repository: "quay.io/us-cdcgov/cdc-nbs-modernization/reporting-pipeline-service"
-  tag: "v1.3.0-prerelease.31084a3"
+  tag: "v1.3.0-prerelease.12cea9e"
 # pullPolicy: IfNotPresent
 
 podAnnotations:
@@ -56,4 +56,4 @@ jdbc:
 
 kafka:
   # e.g. for an AWS MSK provisioned cluster: b-<broker-id>.<cluster-name>.<unique-id>.c<cluster-number>.<aws-region>.amazonaws.com:<port>
-  cluster: "EXAMPLE_KAFKA_ENDPOINT"
+  cluster: "EXAMPLE_KAFKA_ENDPOINT_AND_PORT"


### PR DESCRIPTION
## Description

- Update Kafka endpoint placeholders to include port requirement
- Remove redundant BOOTSTRAP_SERVERS env var in debezium chart
- Update reporting-pipeline-service image tag, unlike previous pre-releases, this version has built-in liquibase migrations and configuration values for debezium/kafka-connect
