### PR TITLE
[APP-897] Modernized Report Execution enabled by default

### DIFF
--- a/charts/modernization-api/values.yaml
+++ b/charts/modernization-api/values.yaml
@@ -171,7 +171,7 @@ ui:
     management:
       # Enable access to System Management screen
       enabled: false
-    execution:
+    reportExecution:
       # Enables access to modernized report execution
       enabled: true
 

--- a/charts/modernization-api/values.yaml
+++ b/charts/modernization-api/values.yaml
@@ -171,7 +171,8 @@ ui:
     management:
       # Enable access to System Management screen
       enabled: false
-    reportExecution:
+  report:
+    execution:
       # Enables access to modernized report execution
       enabled: true
 

--- a/charts/modernization-api/values.yaml
+++ b/charts/modernization-api/values.yaml
@@ -73,7 +73,7 @@ jdbc:
   password: "EXAMPLE_ODSE_DB_USER_PASSWORD"
 
 reportExecution:
-  enabled: false
+  enabled: true
   replicaCount: 1
   image:
     repository: "quay.io/us-cdcgov/cdc-nbs-modernization/nbs7-report-execution"
@@ -171,10 +171,10 @@ ui:
     management:
       # Enable access to System Management screen
       enabled: false
-  report:
+  `:
     execution:
       # Enables access to modernized report execution
-      enabled: false
+      enabled: true
 
 # Below you have the option to override the values for readiness and liveness probes: port, initialDelaySeconds, periodSeconds, and failureThreshold.
 probes:
@@ -185,4 +185,4 @@ probes:
 
 spring:
   liquibase:
-    enabled: false
+    enabled: true

--- a/charts/modernization-api/values.yaml
+++ b/charts/modernization-api/values.yaml
@@ -171,7 +171,6 @@ ui:
     management:
       # Enable access to System Management screen
       enabled: false
-  `:
     execution:
       # Enables access to modernized report execution
       enabled: true

--- a/charts/nbs-gateway/values.yaml
+++ b/charts/nbs-gateway/values.yaml
@@ -58,7 +58,7 @@ system:
 
 reportExecution:
   # Enables routing eligible report execution requests to the modernized report runner.
-  enabled: "false"
+  enabled: "true"
 
 resources: {}
 


### PR DESCRIPTION
## Description

Per guidance from CDC, enables modernized report execution by default in helm.


## Creating a new Helm chart?
1. Does the service require an ingress?
    - Kubernetes Ingress resource are PATH based and only handled by modernization-api and dataingestion-service helm charts. 
    - Currently, names of Kubernetes services have to be predictable if an ingress needs to point to them
2. Chart directory structure (specific environment values.yaml files are allowed at the same level as values.yaml)
    ```  
    |── charts
        ├── new-helm-chart
            ├── templates
            |   ├── tests
            |   ├── helpers.tpl
            |   ├── *.yaml
            |   └─ Chart.yaml
            ├── values.yaml
            └─  README.md
    ```    
3. **Do not include secret values anywhere in a Helm chart, take special care when creating values.yaml**
4. values.yaml is annotated to include parameter description and format as appropriate.
    - values.yaml is considered the production/default parameter file and should point to publically available container registries, if the service is publically available.    

## Updating a Helm Chart?
1. Ensure no secrets have been committed.
2. Ensure updates to existing Helm charts follow the guidelines contained in section [Creating a new Helm chart](#creating-a-new-helm-chart).

