### PR TITLE
Add Linkerd startup wait to all NBS7 charts

### DIFF
--- a/charts/case-notification-service/templates/deployment.yaml
+++ b/charts/case-notification-service/templates/deployment.yaml
@@ -27,6 +27,21 @@ spec:
       serviceAccountName: {{ include "case-notification-service.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if and .Values.linkerd .Values.linkerd.enabled .Values.linkerd.waitForStartup }}
+      initContainers:
+        - name: wait-for-linkerd
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Waiting for Linkerd proxy injector service..."
+              until nslookup linkerd-proxy-injector.linkerd.svc.cluster.local > /dev/null 2>&1; do
+                echo "Linkerd service not found, retrying in 2s..."
+                sleep 2
+              done
+              echo "Linkerd proxy injector service is available!"
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/case-notification-service/values.yaml
+++ b/charts/case-notification-service/values.yaml
@@ -56,3 +56,8 @@ api:
   # The following two values are specified in Keycloak, and are needed by the XML HL7 Parser library (which is part of this case-notification-service).
   clientId: "xml-hl7-parser-keycloak-client"
   secret: "EXAMPLE_XML-HL7-Parser_CLIENT_SECRET"
+
+# Linkerd service mesh configuration
+linkerd:
+  enabled: true
+  waitForStartup: true

--- a/charts/data-processing-service/templates/deployment.yaml
+++ b/charts/data-processing-service/templates/deployment.yaml
@@ -27,6 +27,21 @@ spec:
       serviceAccountName: {{ include "data-processing-service.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if and .Values.linkerd .Values.linkerd.enabled .Values.linkerd.waitForStartup }}
+      initContainers:
+        - name: wait-for-linkerd
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Waiting for Linkerd proxy injector service..."
+              until nslookup linkerd-proxy-injector.linkerd.svc.cluster.local > /dev/null 2>&1; do
+                echo "Linkerd service not found, retrying in 2s..."
+                sleep 2
+              done
+              echo "Linkerd proxy injector service is available!"
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/data-processing-service/values.yaml
+++ b/charts/data-processing-service/values.yaml
@@ -97,3 +97,8 @@ uid:
 timezone: "UTC"
 
 springBootProfile: ""
+
+# Linkerd service mesh configuration
+linkerd:
+  enabled: true
+  waitForStartup: true

--- a/charts/dataingestion-service/templates/deployment.yaml
+++ b/charts/dataingestion-service/templates/deployment.yaml
@@ -27,6 +27,21 @@ spec:
       serviceAccountName: {{ include "dataingestion-service.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if and .Values.linkerd .Values.linkerd.enabled .Values.linkerd.waitForStartup }}
+      initContainers:
+        - name: wait-for-linkerd
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Waiting for Linkerd proxy injector service..."
+              until nslookup linkerd-proxy-injector.linkerd.svc.cluster.local > /dev/null 2>&1; do
+                echo "Linkerd service not found, retrying in 2s..."
+                sleep 2
+              done
+              echo "Linkerd proxy injector service is available!"
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/dataingestion-service/values.yaml
+++ b/charts/dataingestion-service/values.yaml
@@ -136,3 +136,8 @@ probes:
     enabled: true
 
 timezone: "UTC"
+
+# Linkerd service mesh configuration
+linkerd:
+  enabled: true
+  waitForStartup: true

--- a/charts/debezium-case-notifications/templates/deployment.yaml
+++ b/charts/debezium-case-notifications/templates/deployment.yaml
@@ -29,6 +29,21 @@ spec:
           configMap:
             name: {{ include "debezium.name" . }}-connect
             defaultMode: 0744
+      {{- if and .Values.linkerd .Values.linkerd.enabled .Values.linkerd.waitForStartup }}
+      initContainers:
+        - name: wait-for-linkerd
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Waiting for Linkerd proxy injector service..."
+              until nslookup linkerd-proxy-injector.linkerd.svc.cluster.local > /dev/null 2>&1; do
+                echo "Linkerd service not found, retrying in 2s..."
+                sleep 2
+              done
+              echo "Linkerd proxy injector service is available!"
+      {{- end }}      
       containers:
         - name: {{ .Chart.Name }}-connect
           image: "{{ .Values.connect.image.repository }}:{{ .Values.connect.image.tag | default .Chart.AppVersion }}"
@@ -133,6 +148,21 @@ spec:
       {{- with .Values.ui.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if and .Values.linkerd .Values.linkerd.enabled .Values.linkerd.waitForStartup }}
+      initContainers:
+        - name: wait-for-linkerd
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Waiting for Linkerd proxy injector service..."
+              until nslookup linkerd-proxy-injector.linkerd.svc.cluster.local > /dev/null 2>&1; do
+                echo "Linkerd service not found, retrying in 2s..."
+                sleep 2
+              done
+              echo "Linkerd proxy injector service is available!"
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}-ui

--- a/charts/debezium-case-notifications/values.yaml
+++ b/charts/debezium-case-notifications/values.yaml
@@ -169,3 +169,8 @@ ui:
       value: "http://debezium-case-notifications-connect:8083"
     - name: TZ
       value: "UTC"
+
+# Linkerd service mesh configuration
+linkerd:
+  enabled: true
+  waitForStartup: true

--- a/charts/debezium/templates/deployment.yaml
+++ b/charts/debezium/templates/deployment.yaml
@@ -29,6 +29,21 @@ spec:
           configMap:
             name: {{ include "debezium.name" . }}-connect
             defaultMode: 0744
+      {{- if and .Values.linkerd .Values.linkerd.enabled .Values.linkerd.waitForStartup }}
+      initContainers:
+        - name: wait-for-linkerd
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Waiting for Linkerd proxy injector service..."
+              until nslookup linkerd-proxy-injector.linkerd.svc.cluster.local > /dev/null 2>&1; do
+                echo "Linkerd service not found, retrying in 2s..."
+                sleep 2
+              done
+              echo "Linkerd proxy injector service is available!"
+      {{- end }}      
       containers:
         - name: {{ .Chart.Name }}-connect
           image: "{{ .Values.connect.image.repository }}:{{ .Values.connect.image.tag | default .Chart.AppVersion }}"
@@ -111,6 +126,21 @@ spec:
       {{- with .Values.ui.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if and .Values.linkerd .Values.linkerd.enabled .Values.linkerd.waitForStartup }}
+      initContainers:
+        - name: wait-for-linkerd
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Waiting for Linkerd proxy injector service..."
+              until nslookup linkerd-proxy-injector.linkerd.svc.cluster.local > /dev/null 2>&1; do
+                echo "Linkerd service not found, retrying in 2s..."
+                sleep 2
+              done
+              echo "Linkerd proxy injector service is available!"
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}-ui

--- a/charts/debezium/values.yaml
+++ b/charts/debezium/values.yaml
@@ -79,3 +79,8 @@ ui:
       value: "http://debezium-connect:8083"
     - name: TZ
       value: "UTC"
+
+# Linkerd service mesh configuration
+linkerd:
+  enabled: true
+  waitForStartup: true

--- a/charts/elasticsearch/templates/deployment.yaml
+++ b/charts/elasticsearch/templates/deployment.yaml
@@ -25,6 +25,21 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "elasticsearch.serviceAccountName" . }}
+      {{- if and .Values.linkerd .Values.linkerd.enabled .Values.linkerd.waitForStartup }}
+      initContainers:
+        - name: wait-for-linkerd
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Waiting for Linkerd proxy injector service..."
+              until nslookup linkerd-proxy-injector.linkerd.svc.cluster.local > /dev/null 2>&1; do
+                echo "Linkerd service not found, retrying in 2s..."
+                sleep 2
+              done
+              echo "Linkerd proxy injector service is available!"
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -74,3 +74,8 @@ pvc:
     storageRequest: 100Gi
 # Used to create a StorageClass:
 efsFileSystemId: "EXAMPLE_EFS_ID"
+
+# Linkerd service mesh configuration
+linkerd:
+  enabled: true
+  waitForStartup: true

--- a/charts/kafka-connect-sink/templates/deployment.yaml
+++ b/charts/kafka-connect-sink/templates/deployment.yaml
@@ -33,6 +33,21 @@ spec:
       {{- end }}
       {{- end }}
     spec:
+      {{- if and .Values.linkerd .Values.linkerd.enabled .Values.linkerd.waitForStartup }}
+      initContainers:
+        - name: wait-for-linkerd
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Waiting for Linkerd proxy injector service..."
+              until nslookup linkerd-proxy-injector.linkerd.svc.cluster.local > /dev/null 2>&1; do
+                echo "Linkerd service not found, retrying in 2s..."
+                sleep 2
+              done
+              echo "Linkerd proxy injector service is available!"
+      {{- end }}
       containers:
         {{- if .Values.prometheus.jmx.enabled }}
         - name: prometheus-jmx-exporter

--- a/charts/kafka-connect-sink/values.yaml
+++ b/charts/kafka-connect-sink/values.yaml
@@ -130,3 +130,8 @@ probes:
     periodSeconds: 30
     timeoutSeconds: 5
     failureThreshold: 5
+
+# Linkerd service mesh configuration
+linkerd:
+  enabled: true
+  waitForStartup: true

--- a/charts/keycloak/templates/deployment.yaml
+++ b/charts/keycloak/templates/deployment.yaml
@@ -17,8 +17,23 @@ spec:
         app: keycloak
       {{- include "keycloak.selectorLabels" . | nindent 8 }}
     spec:
-      {{- if .Values.initContainers.enabled }}
+      {{- if or .Values.initContainers.enabled (and .Values.linkerd .Values.linkerd.enabled .Values.linkerd.waitForStartup) }}
       initContainers:
+        {{- if and .Values.linkerd .Values.linkerd.enabled .Values.linkerd.waitForStartup }}
+        - name: wait-for-linkerd
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Waiting for Linkerd proxy injector service..."
+              until nslookup linkerd-proxy-injector.linkerd.svc.cluster.local > /dev/null 2>&1; do
+                echo "Linkerd service not found, retrying in 2s..."
+                sleep 2
+              done
+              echo "Linkerd proxy injector service is available!"
+        {{- end }}
+        {{- if .Values.initContainers.enabled }}
         - name: theme-copy
           image: {{ .Values.initContainers.image }}
           command:
@@ -33,6 +48,7 @@ spec:
           volumeMounts:
             - name: kc-persistent-storage
               mountPath: /keycloak/themes
+        {{- end }}
       {{- end }}
 
       containers:

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -68,3 +68,8 @@ resources:
   requests:
     memory: "512Mi"  
     cpu: "250m"
+
+# Linkerd service mesh configuration
+linkerd:
+  enabled: true
+  waitForStartup: true

--- a/charts/modernization-api/templates/deployment-report-execution.yaml
+++ b/charts/modernization-api/templates/deployment-report-execution.yaml
@@ -24,6 +24,21 @@ spec:
       serviceAccountName: {{ include "modernization-api.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- if and .Values.linkerd .Values.linkerd.enabled .Values.linkerd.waitForStartup }}
+      initContainers:
+        - name: wait-for-linkerd
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Waiting for Linkerd proxy injector service..."
+              until nslookup linkerd-proxy-injector.linkerd.svc.cluster.local > /dev/null 2>&1; do
+                echo "Linkerd service not found, retrying in 2s..."
+                sleep 2
+              done
+              echo "Linkerd proxy injector service is available!"
+      {{- end }}
       containers:
         - name: report-execution
           securityContext:

--- a/charts/modernization-api/templates/deployment.yaml
+++ b/charts/modernization-api/templates/deployment.yaml
@@ -27,6 +27,21 @@ spec:
       serviceAccountName: {{ include "modernization-api.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- if and .Values.linkerd .Values.linkerd.enabled .Values.linkerd.waitForStartup }}
+      initContainers:
+        - name: wait-for-linkerd
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Waiting for Linkerd proxy injector service..."
+              until nslookup linkerd-proxy-injector.linkerd.svc.cluster.local > /dev/null 2>&1; do
+                echo "Linkerd service not found, retrying in 2s..."
+                sleep 2
+              done
+              echo "Linkerd proxy injector service is available!"
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/modernization-api/values.yaml
+++ b/charts/modernization-api/values.yaml
@@ -186,3 +186,8 @@ probes:
 spring:
   liquibase:
     enabled: true
+
+# Linkerd service mesh configuration
+linkerd:
+  enabled: true
+  waitForStartup: true

--- a/charts/nbs-gateway/templates/deployment.yaml
+++ b/charts/nbs-gateway/templates/deployment.yaml
@@ -18,6 +18,21 @@ spec:
       labels:
         {{- include "nbs-gateway.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if and .Values.linkerd .Values.linkerd.enabled .Values.linkerd.waitForStartup }}
+      initContainers:
+        - name: wait-for-linkerd
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Waiting for Linkerd proxy injector service..."
+              until nslookup linkerd-proxy-injector.linkerd.svc.cluster.local > /dev/null 2>&1; do
+                echo "Linkerd service not found, retrying in 2s..."
+                sleep 2
+              done
+              echo "Linkerd proxy injector service is available!"
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         args: [

--- a/charts/nbs-gateway/values.yaml
+++ b/charts/nbs-gateway/values.yaml
@@ -107,3 +107,8 @@ probes:
 
 # NBS filename from "logos" folder (WARNING: Size of logo image must be smaller than 1 MB)
 nbsLogoFilename: "nedssLogo.jpg"
+
+# Linkerd service mesh configuration
+linkerd:
+  enabled: true
+  waitForStartup: true

--- a/charts/nifi/templates/deployment.yaml
+++ b/charts/nifi/templates/deployment.yaml
@@ -27,6 +27,21 @@ spec:
       serviceAccountName: {{ include "nifi.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if and .Values.linkerd .Values.linkerd.enabled .Values.linkerd.waitForStartup }}
+      initContainers:
+        - name: wait-for-linkerd
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Waiting for Linkerd proxy injector service..."
+              until nslookup linkerd-proxy-injector.linkerd.svc.cluster.local > /dev/null 2>&1; do
+                echo "Linkerd service not found, retrying in 2s..."
+                sleep 2
+              done
+              echo "Linkerd proxy injector service is available!"
+      {{- end }} 
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/nifi/values.yaml
+++ b/charts/nifi/values.yaml
@@ -109,3 +109,8 @@ singleUserCredentialsPassword: "EXAMPLE_NIFI_ADMIN_USER_PASSWORD"
 # NiFi Sensitive Props Key. Specifies the source string used to derive an encryption key.
 # The Sensitive Properties Key is not the encryption key itself, but the password from which NiFi derives the actual encryption key.
 nifiSensitivePropsKey: "EXAMPLE_NIFI_SENSITIVE_PROPS"
+
+# Linkerd service mesh configuration
+linkerd:
+  enabled: true
+  waitForStartup: true

--- a/charts/reporting-pipeline-service/templates/deployment.yaml
+++ b/charts/reporting-pipeline-service/templates/deployment.yaml
@@ -20,6 +20,21 @@ spec:
     spec:
       # Service account name for the pod.
       serviceAccountName: {{ .Chart.Name }}
+      {{- if and .Values.linkerd .Values.linkerd.enabled .Values.linkerd.waitForStartup }}
+      initContainers:
+        - name: wait-for-linkerd
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Waiting for Linkerd proxy injector service..."
+              until nslookup linkerd-proxy-injector.linkerd.svc.cluster.local > /dev/null 2>&1; do
+                echo "Linkerd service not found, retrying in 2s..."
+                sleep 2
+              done
+              echo "Linkerd proxy injector service is available!"
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/reporting-pipeline-service/values.yaml
+++ b/charts/reporting-pipeline-service/values.yaml
@@ -53,3 +53,8 @@ jdbc:
 kafka:
   # e.g. for an AWS MSK provisioned cluster: b-<broker-id>.<cluster-name>.<unique-id>.c<cluster-number>.<aws-region>.amazonaws.com:<port>
   cluster: "EXAMPLE_KAFKA_ENDPOINT_AND_PORT"
+
+# Linkerd service mesh configuration
+linkerd:
+  enabled: true
+  waitForStartup: true


### PR DESCRIPTION
## Summary

Adds init container to all NBS7 Helm charts that waits for Linkerd proxy injector before starting application containers. This ensures consistent sidecar injection during cluster scale operations.

## Problem

During node scale up/down, pods could start before Linkerd was ready, causing:
- Missing sidecars (`1/1` instead of `2/2`)
- Broken mTLS between services
- Required manual `kubectl rollout restart` to fix

## Solution

Added an init container that checks Linkerd availability via DNS before the main container starts:

## Charts Updated

- modernization-api (2 deployments)
- dataingestion-service
- case-notification-service
- reporting-pipeline-service
- nifi
- data-processing-service
- elasticsearch
- keycloak
- nbs-gateway
- debezium (2 deployments)
- debezium-case-notifications (2 deployments)
- kafka-connect-sink

## Testing

- All charts render init container correctly via `helm template`
- page-builder-api tested on nbs7-dev2-eks (PR #1362) - pods now show `2/2`
- Deployed updated charts on Dev2:
  - data-processing-service: 1/1 → 2/2 
  - dataingestion-service: 1/1 → 2/2 
  - debezium-case-notifications: 1/1 → 2/2 
- Init container logs confirm: "Linkerd proxy injector service is available!"
- Full node scale-down/up test planned for post-7.13 release

## Related

- Jira: DEV-490 https://cdc-nbs.atlassian.net/browse/DEV-490
- Prior PR: #1362 (page-builder-api proof of concept)

