### PR TITLE
disable patient file by default

### DIFF
--- a/charts/modernization-api/values.yaml
+++ b/charts/modernization-api/values.yaml
@@ -153,7 +153,7 @@ ui:
   patient:
     file:
       # Enables access to the modernized Patient File
-      enabled: true
+      enabled: false
       # Enables presence of Merge History card in Patient File
       mergeHistory:
         enabled: false

--- a/charts/nbs-gateway/values.yaml
+++ b/charts/nbs-gateway/values.yaml
@@ -31,7 +31,7 @@ welcome:
 patient:
   file:
     # Enables routing from NBS6 pages to the modernized Patient File
-    enabled: true
+    enabled: false
 
 pageBuilder:
   enabled: "false"


### PR DESCRIPTION
## Description

Please include a summary of the changes and any key information a reviewer may need. Review the appropriate section below.


Disables Patient File by default

## Creating a new Helm chart?
1. Does the service require an ingress?
    - Kubernetes Ingress resource are PATH based and only handled by modernization-api and dataingestion-service helm charts. 
    - Currently, names of Kubernetes services have to be predictable if an ingress needs to point to them
2. Chart directory structure (specific environment values.yaml files are allowed at the same level as values.yaml)
    ```  
    |── charts
        ├── new-helm-chart
            ├── templates
            |   ├── tests
            |   ├── helpers.tpl
            |   ├── *.yaml
            |   └─ Chart.yaml
            ├── values.yaml
            └─  README.md
    ```    
3. **Do not include secret values anywhere in a Helm chart, take special care when creating values.yaml**
4. values.yaml is annotated to include parameter description and format as appropriate.
    - values.yaml is considered the production/default parameter file and should point to publically available container registries, if the service is publically available.    

## Updating a Helm Chart?
1. Ensure no secrets have been committed.
2. Ensure updates to existing Helm charts follow the guidelines contained in section [Creating a new Helm chart](#creating-a-new-helm-chart).

