### PR TITLE
fix(rtr): skip linkerd outbound port

### DIFF
--- a/charts/reporting-pipeline-service/values.yaml
+++ b/charts/reporting-pipeline-service/values.yaml
@@ -12,6 +12,7 @@ image:
 # pullPolicy: IfNotPresent
 
 podAnnotations:
+  config.linkerd.io/skip-outbound-ports: "EXAMPLE_DB_PORT"
   prometheus.io/scrape: "true"
   prometheus.io/path: "/actuator/prometheus"
   prometheus.io/port: "8081"


### PR DESCRIPTION
## Description
Configure reporting-pipeline-service pod annotations to skip Linkerd outbound port for database connections.