### PR TITLE
[GA Release] Update tags with most recent pushes to Quay

### DIFF
--- a/charts/case-notification-service/values.yaml
+++ b/charts/case-notification-service/values.yaml
@@ -6,7 +6,7 @@ authUri: "http://keycloak.default.svc.cluster.local/auth/realms/NBS"
 image:
   repository: "quay.io/us-cdcgov/cdc-nbs-modernization/nnd-case-notification-service/case-notification-service"
   pullPolicy: IfNotPresent
-  tag: "v1.0.3"
+  tag: "v1.0.6"
 
 imagePullSecrets: []
 

--- a/charts/dataingestion-service/values.yaml
+++ b/charts/dataingestion-service/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: "quay.io/us-cdcgov/cdc-nbs-modernization/data-ingestion-service"
   pullPolicy: IfNotPresent
-  tag: "v1.3.1"
+  tag: "v1.4.1"
 
 imagePullSecrets: []
 

--- a/charts/dataingestion-service/values.yaml
+++ b/charts/dataingestion-service/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: "quay.io/us-cdcgov/cdc-nbs-modernization/data-ingestion-service"
   pullPolicy: IfNotPresent
-  tag: "v1.4.1"
+  tag: "v1.4.2"
 
 imagePullSecrets: []
 

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -4,7 +4,7 @@ image:
   #repository: "public.ecr.aws/o1z7u2g7/cdc-nbs-modernization/elasticsearch"
   repository: "quay.io/us-cdcgov/cdc-nbs-modernization/elasticsearch"
   pullPolicy: IfNotPresent
-  tag: "v1.0.3"
+  tag: "v1.0.4"
 
 imagePullSecrets: []
 

--- a/charts/modernization-api/values.yaml
+++ b/charts/modernization-api/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 image:
   repository: "quay.io/us-cdcgov/cdc-nbs-modernization/modernization-api"
   pullPolicy: IfNotPresent
-  tag: "v1.5.0"
+  tag: "v1.5.1"
 
 imagePullSecrets: [] # Used by both pods (i.e. modernization-api and modernization-api-report-execution)
 
@@ -100,7 +100,7 @@ reportExecution:
   image:
     repository: "quay.io/us-cdcgov/cdc-nbs-modernization/report-execution"
     pullPolicy: IfNotPresent
-    tag: "v1.0.0"
+    tag: "v1.0.1"
   service:
     type: ClusterIP
     port: 8001

--- a/charts/modernization-api/values.yaml
+++ b/charts/modernization-api/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 image:
   repository: "quay.io/us-cdcgov/cdc-nbs-modernization/modernization-api"
   pullPolicy: IfNotPresent
-  tag: "v1.5.1"
+  tag: "v1.5.2"
 
 imagePullSecrets: [] # Used by both pods (i.e. modernization-api and modernization-api-report-execution)
 

--- a/charts/nbs-gateway/values.yaml
+++ b/charts/nbs-gateway/values.yaml
@@ -7,7 +7,7 @@ image:
   #repository: "public.ecr.aws/o1z7u2g7/cdc-nbs-modernization/nbs-gateway"
   repository: "quay.io/us-cdcgov/cdc-nbs-modernization/nbs-gateway"
   pullPolicy: IfNotPresent
-  tag: "v1.5.0"
+  tag: "v1.5.1"
 
 gatewayService:
   ports:

--- a/charts/page-builder-api/values.yaml
+++ b/charts/page-builder-api/values.yaml
@@ -5,7 +5,7 @@ env: "prod"
 image:
   repository: "quay.io/us-cdcgov/cdc-nbs-modernization/page-builder-api"
   pullPolicy: IfNotPresent
-  tag: "v1.4.0"
+  tag: "v1.4.1"
 
 # Host URL for application
 ingressHost: "app.EXAMPLE_DOMAIN"


### PR DESCRIPTION
## Description

This PR updates the tag values to reflect the most recent images for the following:

- case-notification-service
- data-ingestion-service
- elasticsearch
- modernization-api
- report-execution
- nbs-gateway
- page-builder-api

## Creating a new Helm chart?
1. Does the service require an ingress?
    - Kubernetes Ingress resource are PATH based and only handled by modernization-api and dataingestion-service helm charts. 
    - Currently, names of Kubernetes services have to be predictable if an ingress needs to point to them
2. Chart directory structure (specific environment values.yaml files are allowed at the same level as values.yaml)
    ```  
    |── charts
        ├── new-helm-chart
            ├── templates
            |   ├── tests
            |   ├── helpers.tpl
            |   ├── *.yaml
            |   └─ Chart.yaml
            ├── values.yaml
            └─  README.md
    ```    
3. **Do not include secret values anywhere in a Helm chart, take special care when creating values.yaml**
4. values.yaml is annotated to include parameter description and format as appropriate.
    - values.yaml is considered the production/default parameter file and should point to publically available container registries, if the service is publically available.    

## Updating a Helm Chart?
1. Ensure no secrets have been committed.
2. Ensure updates to existing Helm charts follow the guidelines contained in section [Creating a new Helm chart](#creating-a-new-helm-chart).

