### PR TITLE
Update chart version and appVersion for 7.13.0 release

### DIFF
--- a/charts/case-notification-service/Chart.yaml
+++ b/charts/case-notification-service/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 #appVersion: "1.16.0"
-appVersion: "7.12.0"
+appVersion: "7.13.0"

--- a/charts/data-compare-api-service/Chart.yaml
+++ b/charts/data-compare-api-service/Chart.yaml
@@ -22,4 +22,4 @@ version: 1.0.7
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 #appVersion: "1.16.0"
-appVersion: "7.7.0"
+appVersion: "7.13.0"

--- a/charts/data-compare-processor-service/Chart.yaml
+++ b/charts/data-compare-processor-service/Chart.yaml
@@ -22,4 +22,4 @@ version: 1.0.7
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 #appVersion: "1.16.0"
-appVersion: "7.7.0"
+appVersion: "7.13.0"

--- a/charts/data-processing-service/Chart.yaml
+++ b/charts/data-processing-service/Chart.yaml
@@ -21,4 +21,4 @@ version: 1.0.6
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "7.12.0"
+appVersion: "7.13.0"

--- a/charts/dataingestion-service/Chart.yaml
+++ b/charts/dataingestion-service/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.1
+version: 1.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 #appVersion: "1.16.0"
-appVersion: "7.12.0"
+appVersion: "7.13.0"

--- a/charts/debezium-case-notifications/Chart.yaml
+++ b/charts/debezium-case-notifications/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 
 version: 0.0.2
 
-appVersion: v0-0-2
+appVersion: "7.13.0"

--- a/charts/debezium/Chart.yaml
+++ b/charts/debezium/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 
 version: 1.3.0
 
-appVersion: v0-0-2
+appVersion: "7.13.0"

--- a/charts/elasticsearch/Chart.yaml
+++ b/charts/elasticsearch/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "7.12.0"
+appVersion: "7.13.0"

--- a/charts/kafka-connect-sink/Chart.yaml
+++ b/charts/kafka-connect-sink/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "7.13.0"
 description: A Helm chart for Confluent Kafka Connect on Kubernetes
 name: cp-kafka-connect
 version: 1.3.0

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.0"
+appVersion: "7.13.0"

--- a/charts/modernization-api/Chart.yaml
+++ b/charts/modernization-api/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.1
+version: 1.5.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "7.12.0"
+appVersion: "7.13.0"

--- a/charts/nbs-gateway/Chart.yaml
+++ b/charts/nbs-gateway/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.1
+version: 1.5.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "7.12.0"
+appVersion: "7.13.0"

--- a/charts/nbs-ingress/Chart.yaml
+++ b/charts/nbs-ingress/Chart.yaml
@@ -3,4 +3,4 @@ name: nbs-ingress
 description: NBS7 Ingress routing resources — decoupled from application charts
 type: application
 version: 1.0.0
-appVersion: "1.0.0"
+appVersion: "7.13.0"

--- a/charts/nbs6-ingress/Chart.yaml
+++ b/charts/nbs6-ingress/Chart.yaml
@@ -3,4 +3,4 @@ name: nbs6-ingress
 description: NBS6 (Classic/WildFly) Ingress routing — decoupled from the nbs6 application chart
 type: application
 version: 1.0.0
-appVersion: "1.0.0"
+appVersion: "7.13.0"

--- a/charts/nifi/Chart.yaml
+++ b/charts/nifi/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.7
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "7.11.1"
+appVersion: "7.13.0"

--- a/charts/page-builder-api/Chart.yaml
+++ b/charts/page-builder-api/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.0
+version: 1.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "7.12.0"
+appVersion: "7.13.0"


### PR DESCRIPTION
## Description

Update version strings for NBS 7.13.0 release


## Creating a new Helm chart?
1. Does the service require an ingress?
    - Kubernetes Ingress resource are PATH based and only handled by modernization-api and dataingestion-service helm charts. 
    - Currently, names of Kubernetes services have to be predictable if an ingress needs to point to them
2. Chart directory structure (specific environment values.yaml files are allowed at the same level as values.yaml)
    ```  
    |── charts
        ├── new-helm-chart
            ├── templates
            |   ├── tests
            |   ├── helpers.tpl
            |   ├── *.yaml
            |   └─ Chart.yaml
            ├── values.yaml
            └─  README.md
    ```    
3. **Do not include secret values anywhere in a Helm chart, take special care when creating values.yaml**
4. values.yaml is annotated to include parameter description and format as appropriate.
    - values.yaml is considered the production/default parameter file and should point to publically available container registries, if the service is publically available.    

## Updating a Helm Chart?
1. Ensure no secrets have been committed.
2. Ensure updates to existing Helm charts follow the guidelines contained in section [Creating a new Helm chart](#creating-a-new-helm-chart).

